### PR TITLE
Carbon messaging migration

### DIFF
--- a/carbon-mss/components/org.wso2.carbon.mss/pom.xml
+++ b/carbon-mss/components/org.wso2.carbon.mss/pom.xml
@@ -131,6 +131,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -321,7 +325,8 @@
             org.wso2.carbon.metrics.manager.*;version="${carbon.metrics.version.range}",
             org.wso2.carbon.metrics.impl.*;version="${carbon.metrics.version.range}",
             org.wso2.carbon.databridge.agent.*;version="${carbon.analytics.common.version.range}",
-            org.wso2.carbon.databridge.commons.*;version="${carbon.analytics.common.version.range}"
+            org.wso2.carbon.databridge.commons.*;version="${carbon.analytics.common.version.range}",
+            org.wso2.carbon.messaging.*;version="${org.wso2.carbon.messaging.version.range}"
         </import.package>
         <provide.capability>
             osgi.service;effective:=active;

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/MicroservicesRunner.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/MicroservicesRunner.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.kernel.transports.TransportManager;
 import org.wso2.carbon.mss.internal.MSSNettyServerInitializer;
 import org.wso2.carbon.mss.internal.MicroservicesRegistry;
-import org.wso2.carbon.transport.http.netty.internal.NettyTransportDataHolder;
+import org.wso2.carbon.transport.http.netty.internal.NettyTransportContextHolder;
 import org.wso2.carbon.transport.http.netty.internal.config.ListenerConfiguration;
 import org.wso2.carbon.transport.http.netty.internal.config.TransportsConfiguration;
 import org.wso2.carbon.transport.http.netty.internal.config.YAMLTransportConfigurationBuilder;
@@ -52,7 +52,7 @@ public class MicroservicesRunner {
      */
     public MicroservicesRunner(int... ports) {
         for (int port : ports) {
-            NettyTransportDataHolder nettyTransportDataHolder = NettyTransportDataHolder.getInstance();
+            NettyTransportContextHolder nettyTransportDataHolder = NettyTransportContextHolder.getInstance();
             ListenerConfiguration listenerConfiguration =
                     new ListenerConfiguration("netty-" + port, "0.0.0.0", port);
             NettyListener listener = new NettyListener(listenerConfiguration);
@@ -74,7 +74,7 @@ public class MicroservicesRunner {
     public MicroservicesRunner() {
         TransportsConfiguration trpConfig = YAMLTransportConfigurationBuilder.build();
         Set<ListenerConfiguration> listenerConfigurations = trpConfig.getListenerConfigurations();
-        NettyTransportDataHolder nettyTransportDataHolder = NettyTransportDataHolder.getInstance();
+        NettyTransportContextHolder nettyTransportDataHolder = NettyTransportContextHolder.getInstance();
         for (ListenerConfiguration listenerConfiguration : listenerConfigurations) {
             NettyListener listener = new NettyListener(listenerConfiguration);
             transportManager.registerTransport(listener);

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/DataHolder.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/DataHolder.java
@@ -23,7 +23,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.kernel.transports.CarbonTransport;
-import org.wso2.carbon.transport.http.netty.listener.CarbonNettyServerInitializer;
+import org.wso2.carbon.messaging.CarbonTransportInitializer;
 
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -39,7 +39,7 @@ public class DataHolder {
 
     private static DataHolder instance = new DataHolder();
     private BundleContext bundleContext;
-    private Map<String, ServiceRegistration<CarbonNettyServerInitializer>> carbonTransports = new HashMap<>();
+    private Map<String, ServiceRegistration<CarbonTransportInitializer>> carbonTransports = new HashMap<>();
 
     private DataHolder() {
     }
@@ -66,8 +66,8 @@ public class DataHolder {
         httpInitParams.put(CHANNEL_ID_KEY, channelKey);
         MSSNettyServerInitializer gatewayNettyInitializer =
                 new MSSNettyServerInitializer(MicroservicesRegistry.getInstance());
-        ServiceRegistration<CarbonNettyServerInitializer> service =
-                bundleContext.registerService(CarbonNettyServerInitializer.class,
+        ServiceRegistration<CarbonTransportInitializer> service =
+                bundleContext.registerService(CarbonTransportInitializer.class,
                         gatewayNettyInitializer, httpInitParams);
         carbonTransports.put(channelKey, service);
     }

--- a/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/MSSNettyServerInitializer.java
+++ b/carbon-mss/components/org.wso2.carbon.mss/src/main/java/org/wso2/carbon/mss/internal/MSSNettyServerInitializer.java
@@ -25,16 +25,16 @@ import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import org.wso2.carbon.messaging.CarbonTransportInitializer;
 import org.wso2.carbon.mss.internal.router.HttpDispatcher;
 import org.wso2.carbon.mss.internal.router.RequestRouter;
-import org.wso2.carbon.transport.http.netty.listener.CarbonNettyServerInitializer;
 
 import java.util.Map;
 
 /**
  * Netty Transport ServerInitializer for the Microservices Server.
  */
-public class MSSNettyServerInitializer implements CarbonNettyServerInitializer {
+public class MSSNettyServerInitializer implements CarbonTransportInitializer {
 
     private DefaultEventExecutorGroup eventExecutorGroup;
 
@@ -50,7 +50,9 @@ public class MSSNettyServerInitializer implements CarbonNettyServerInitializer {
                 new DefaultEventExecutorGroup(Integer.parseInt(map.get(MSSConstants.EXECUTOR_THREAD_POOL_SIZE_KEY)));
     }
 
-    public void initChannel(SocketChannel channel) {
+    @Override
+    public void initChannel(Object objectChannel) {
+        SocketChannel channel = (SocketChannel) objectChannel;
         ChannelPipeline pipeline = channel.pipeline();
         pipeline.addLast("compressor", new HttpContentCompressor());
         pipeline.addLast("decoder", new HttpRequestDecoder());
@@ -59,5 +61,10 @@ public class MSSNettyServerInitializer implements CarbonNettyServerInitializer {
         pipeline.addLast("router",
                 new RequestRouter(microservicesRegistry.getHttpResourceHandler(), 0));
         pipeline.addLast(eventExecutorGroup, "dispatcher", new HttpDispatcher());
+    }
+
+    @Override
+    public boolean isServerInitializer() {
+        return true;
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -453,7 +453,11 @@
                 <artifactId>asm-all</artifactId>
                 <version>${asm.all.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.wso2.carbon.messaging</groupId>
+                <artifactId>org.wso2.carbon.messaging</artifactId>
+                <version>${org.wso2.carbon.messaging.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -474,8 +478,10 @@
         <!-- Dependencies -->
         <carbon.kernel.version>5.0.0</carbon.kernel.version>
         <carbon.kernel.version.range>[5.0,6)</carbon.kernel.version.range>
-        <org.wso2.carbon.transport.http.netty.version>1.0.0</org.wso2.carbon.transport.http.netty.version>
-        <org.wso2.carbon.transport.http.netty.version.range>[1.0,2)</org.wso2.carbon.transport.http.netty.version.range>
+        <org.wso2.carbon.transport.http.netty.version>2.0.0-SNAPSHOT</org.wso2.carbon.transport.http.netty.version>
+        <org.wso2.carbon.transport.http.netty.version.range>[2.0, 2.1)</org.wso2.carbon.transport.http.netty.version.range>
+        <org.wso2.carbon.messaging.version>1.0.0-alpha</org.wso2.carbon.messaging.version>
+        <org.wso2.carbon.messaging.version.range>[1.0.0, 2.0.0)</org.wso2.carbon.messaging.version.range>
         <carbon.mss.version>1.0.0-SNAPSHOT</carbon.mss.version>
         <carbon.metrics.version>1.2.0</carbon.metrics.version>
         <carbon.metrics.version.range>[1.2,2)</carbon.metrics.version.range>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -64,6 +64,18 @@
             <version>${carbon.mss.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.transport</groupId>
+            <artifactId>org.wso2.carbon.transport.http.netty.feature</artifactId>
+            <version>${org.wso2.carbon.transport.http.netty.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.messaging.feature</artifactId>
+            <version>${org.wso2.carbon.messaging.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -137,6 +149,14 @@
                                     <id>org.wso2.carbon.spi.fly.feature</id>
                                     <version>${carbon.mss.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.transport.http.netty.feature</id>
+                                    <version>${org.wso2.carbon.transport.http.netty.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.messaging.feature</id>
+                                    <version>${org.wso2.carbon.messaging.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -200,6 +220,14 @@
                                 <feature>
                                     <id>org.wso2.carbon.spi.fly.feature</id>
                                     <version>${carbon.mss.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.transport.http.netty.feature.group</id>
+                                    <version>${org.wso2.carbon.transport.http.netty.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.messaging.feature.group</id>
+                                    <version>${org.wso2.carbon.messaging.version}</version>
                                 </feature>
                             </features>
                         </configuration>


### PR DESCRIPTION
This pull requests contains all the necessary changes that requires to build MSS with carbon-transports version 2.0.0 and carbon-messaging version 1.0.0. However, please note that you have to build latest carbon-transports before building MSS as we are depending on the snapshot. 

Key changes : 

1.  Changing `CarbonNettyServerInitializer` to `CarbonTransportInitializer`. 
2.  Moving `NettyInitializerCapabilityProvider` in to MSS as `MSSInitializerCapabilityProvider`.
The rational for this change is, with the new carbon-transports, it is not a must to provide an 
Initializer as it starts with the default Initializer. If any product wants to override the default Initializer 
it can be done by registering its own initializer. 


     