### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/router/BasicHttpResponder.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/BasicHttpResponder.java
@@ -58,7 +58,7 @@ public class BasicHttpResponder extends AbstractHttpResponder {
     @Override
     public ChunkResponder sendChunkStart(HttpResponseStatus status, @Nullable Multimap<String, String> headers) {
         Preconditions.checkArgument(responded.compareAndSet(false, true), "Response has been already sent");
-        Preconditions.checkArgument((status.code() >= 200 && status.code() < 210), "Http Chunk Failure");
+        Preconditions.checkArgument(status.code() >= 200 && status.code() < 210, "Http Chunk Failure");
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
 
         setCustomHeaders(response, headers);

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModel.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModel.java
@@ -87,18 +87,18 @@ public final class HttpResourceModel {
     }
 
     private List<String> parseConsumesMediaTypes() {
-        String[] consumesMediaTypeArr = (method.isAnnotationPresent(Consumes.class)) ?
+        String[] consumesMediaTypeArr = method.isAnnotationPresent(Consumes.class) ?
                 method.getAnnotation(Consumes.class).value() :
-                (handler.getClass().isAnnotationPresent(Consumes.class)) ?
+                handler.getClass().isAnnotationPresent(Consumes.class) ?
                         handler.getClass().getAnnotation(Consumes.class).value() :
                         ANY_MEDIA_TYPE;
         return Arrays.asList(consumesMediaTypeArr);
     }
 
     private List<String> parseProducesMediaTypes() {
-        String[] producesMediaTypeArr = (method.isAnnotationPresent(Produces.class)) ?
+        String[] producesMediaTypeArr = method.isAnnotationPresent(Produces.class) ?
                 method.getAnnotation(Produces.class).value() :
-                (handler.getClass().isAnnotationPresent(Produces.class)) ?
+                handler.getClass().isAnnotationPresent(Produces.class) ?
                         handler.getClass().getAnnotation(Produces.class).value() :
                         ANY_MEDIA_TYPE;
         return Arrays.asList(producesMediaTypeArr);

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModelProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModelProcessor.java
@@ -78,7 +78,7 @@ public class HttpResourceModelProcessor {
                 String acceptType = "*/*";
                 if (!producesMediaTypes.contains("*/*") && acceptTypes != null) {
                     acceptType =
-                            (acceptTypes.contains("*/*")) ? producesMediaTypes.get(0) :
+                            acceptTypes.contains("*/*") ? producesMediaTypes.get(0) :
                                     producesMediaTypes.stream().filter(acceptTypes::contains).findFirst().get();
                 }
                 int idx = 0;

--- a/core/src/main/java/org/wso2/msf4j/internal/router/SSLHandlerFactory.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/SSLHandlerFactory.java
@@ -81,7 +81,7 @@ public class SSLHandlerFactory {
             ks.load(is, keyStorePassword.toCharArray());
         } catch (Exception ex) {
             if (ex instanceof RuntimeException) {
-                throw ((RuntimeException) ex);
+                throw (RuntimeException) ex;
             }
             throw new IOException(ex);
         } finally {

--- a/samples/petstore/microservices/security/src/main/java/org/wso2/msf4j/examples/petstore/security/ldap/LDAPUserStoreManager.java
+++ b/samples/petstore/microservices/security/src/main/java/org/wso2/msf4j/examples/petstore/security/ldap/LDAPUserStoreManager.java
@@ -292,7 +292,7 @@ public class LDAPUserStoreManager {
         if ((username != null) && (!username.equals(""))) {
             props.put(Context.SECURITY_AUTHENTICATION, "simple");
             props.put(Context.SECURITY_PRINCIPAL, username);
-            props.put(Context.SECURITY_CREDENTIALS, ((password == null) ? "" : password));
+            props.put(Context.SECURITY_CREDENTIALS, (password == null) ? "" : password);
         }
 
         return new InitialDirContext(props);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava