### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:HiddenFieldCheck, squid:S1118

### DIFF
--- a/analytics/msf4j-analytics/src/main/java/org/wso2/msf4j/analytics/httpmonitoring/HTTPMonitoringInterceptor.java
+++ b/analytics/msf4j-analytics/src/main/java/org/wso2/msf4j/analytics/httpmonitoring/HTTPMonitoringInterceptor.java
@@ -161,12 +161,12 @@ public class HTTPMonitoringInterceptor implements Interceptor {
             httpMonitoringEvent.setStartNanoTime(System.nanoTime());
             if (serviceClass == null) {
                 Method method = serviceMethodInfo.getMethod();
-                Class<?> serviceClass = method.getDeclaringClass();
-                this.serviceClass = serviceClass.getName();
-                serviceName = serviceClass.getSimpleName();
+                Class<?> declaringClass = method.getDeclaringClass();
+                this.serviceClass = declaringClass.getName();
+                serviceName = declaringClass.getSimpleName();
                 serviceMethod = method.getName();
-                if (serviceClass.isAnnotationPresent(Path.class)) {
-                    Path path = serviceClass.getAnnotation(Path.class);
+                if (declaringClass.isAnnotationPresent(Path.class)) {
+                    Path path = declaringClass.getAnnotation(Path.class);
                     servicePath = path.value();
                 }
             }

--- a/analytics/msf4j-analytics/src/main/java/org/wso2/msf4j/analytics/metrics/MetricsInterceptor.java
+++ b/analytics/msf4j-analytics/src/main/java/org/wso2/msf4j/analytics/metrics/MetricsInterceptor.java
@@ -163,6 +163,8 @@ public class MetricsInterceptor implements Interceptor {
             return org.wso2.carbon.metrics.manager.Level.TRACE;
         case ALL:
             return org.wso2.carbon.metrics.manager.Level.ALL;
+        default:
+            break;
         }
         return org.wso2.carbon.metrics.manager.Level.INFO;
     }

--- a/samples/petstore/microservices/pet/src/main/java/org/wso2/msf4j/examples/petstore/pet/PetConstants.java
+++ b/samples/petstore/microservices/pet/src/main/java/org/wso2/msf4j/examples/petstore/pet/PetConstants.java
@@ -25,4 +25,6 @@ public final class PetConstants {
     public static final String CATEGORY_KEY_PREFIX = "petstore:pet:category.";
 
     public static final String PET_ID_KEY_PREFIX = "petstore:pet:id.";
+
+    private PetConstants() {}
 }

--- a/samples/petstore/microservices/transaction/src/main/java/org/wso2/msf4j/examples/petstore/transaction/TxnConstants.java
+++ b/samples/petstore/microservices/transaction/src/main/java/org/wso2/msf4j/examples/petstore/transaction/TxnConstants.java
@@ -24,4 +24,5 @@ public final class TxnConstants {
 
     public static final String ORDER_KEY_PREFIX = "petstore:transaction:order.";
 
+    private TxnConstants() {}
 }

--- a/samples/petstore/util/src/main/java/org/wso2/msf4j/examples/petstore/util/JedisUtil.java
+++ b/samples/petstore/util/src/main/java/org/wso2/msf4j/examples/petstore/util/JedisUtil.java
@@ -62,6 +62,8 @@ public class JedisUtil {
 
     private static Jedis master = getJedis();
 
+    private JedisUtil() {}
+
     public static String getSentinelHost() {
         return SENTINEL1_HOST;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:HiddenFieldCheck - Local variables should not shadow class fields.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava