### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
@@ -21,4 +21,6 @@ package org.wso2.msf4j.internal;
 public class MSF4JConstants {
 
     public static final String EXECUTOR_THREAD_POOL_SIZE_KEY = "execThreadPoolSize";
+
+    private MSF4JConstants() {}
 }

--- a/core/src/main/java/org/wso2/msf4j/internal/mime/MimeMapper.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/mime/MimeMapper.java
@@ -32,6 +32,8 @@ public class MimeMapper {
     private static Properties mimeMap = null;
     private static final Logger log = LoggerFactory.getLogger(MimeMapper.class);
 
+    private MimeMapper() {}
+
     private static void loadMimeMap() throws IOException {
         mimeMap = new Properties();
         InputStream inputStream = MimeMapper.class.getClassLoader()

--- a/core/src/main/java/org/wso2/msf4j/internal/router/beanconversion/BeanConverter.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/beanconversion/BeanConverter.java
@@ -22,6 +22,8 @@ package org.wso2.msf4j.internal.router.beanconversion;
  */
 public class BeanConverter {
 
+    private BeanConverter() {}
+
     public static MediaTypeConverter instance(String mediaType) throws BeanConversionException {
         if (mediaType.equalsIgnoreCase("text/json")
                 || mediaType.equalsIgnoreCase("application/json")) {

--- a/core/src/main/java/org/wso2/msf4j/security/oauth2/IntrospectionResponse.java
+++ b/core/src/main/java/org/wso2/msf4j/security/oauth2/IntrospectionResponse.java
@@ -110,4 +110,6 @@ public final class IntrospectionResponse {
      * understanding the error that occurred.
      */
     public static final String ERROR_DESCRIPTION = "error_description";
+
+    private IntrospectionResponse() {}
 }

--- a/core/src/main/java/org/wso2/msf4j/util/SystemVariableUtil.java
+++ b/core/src/main/java/org/wso2/msf4j/util/SystemVariableUtil.java
@@ -22,6 +22,8 @@ package org.wso2.msf4j.util;
  */
 public class SystemVariableUtil {
 
+    private SystemVariableUtil() {}
+
     public static String getValue(String variableName, String defaultValue) {
         String value;
         if (System.getProperty(variableName) != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava