### PR TITLE
Upgrade to Carbon 5.1.0 and changed dependentComponentName to requiredByComponentName

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -354,7 +354,7 @@
         <carbon.component>
             startup.listener;componentName="wso2-microservices-server";requiredService="org.wso2.msf4j.Microservice,org.wso2.msf4j.Interceptor",
             osgi.service;
-            objectClass="org.wso2.msf4j.internal.MicroservicesServerSC";dependentComponentName="carbon-transport-mgt",
+            objectClass="org.wso2.msf4j.internal.MicroservicesServerSC";requiredByComponentName="carbon-transport-mgt",
             osgi.service; objectClass="org.wso2.carbon.messaging.CarbonMessageProcessor"
         </carbon.component>
     </properties>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -564,7 +564,7 @@
         <maven.archetype.version>2.4</maven.archetype.version>
 
         <!-- Dependencies -->
-        <carbon.kernel.version>5.1.0-alpha2</carbon.kernel.version>
+        <carbon.kernel.version>5.1.0</carbon.kernel.version>
         <carbon.kernel.version.range>[5.0.0,6.0.0)</carbon.kernel.version.range>
         <carbon.messaging.version>1.0.3</carbon.messaging.version>
         <carbon.messaging.version.range>[1.0.2,2)</carbon.messaging.version.range>


### PR DESCRIPTION
Please review and merge after Carbon 5.1.0 is released.