### PR TITLE
Adding Special VM Property to surefire plugin so can get the pid easily

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -191,6 +191,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Dmsf4jTestRunning</argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/features/feature-test/pom.xml
+++ b/features/feature-test/pom.xml
@@ -235,6 +235,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Dmsf4jTestRunning</argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -123,6 +123,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Dmsf4jTestRunning</argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>


### PR DESCRIPTION
We can run the below script and kill the servers before starting the tests
#!/bin/bash
echo Killing all msf4j testservers ...
ps ax | grep Dmsf4jTestRunning | grep -v grep | awk '{print $1}' | xargs kill -9
exit 0