### PR TITLE
Fix wso2das-msf4j-tracing capp - wso2das gadget resource path issue

### DIFF
--- a/analytics/wso2das-tracing-capp/capp-content/GadgetMSF4JTracing_1.0.0/msf4j-tracing/gadget.json
+++ b/analytics/wso2das-tracing-capp/capp-content/GadgetMSF4JTracing_1.0.0/msf4j-tracing/gadget.json
@@ -2,8 +2,8 @@
     "id": "msf4j-message-tracing",
     "title": "MSF4J Message Tracing",
     "type": "gadget",
-    "thumbnail": "store://gadget/msf4j-tracing/icon.png",
+    "thumbnail": "local://store/gadget/msf4j-tracing/icon.png",
     "data": {
-        "url": "store://gadget/msf4j-tracing/index.xml"
+        "url": "local://store/gadget/msf4j-tracing/index.xml"
     }
 }


### PR DESCRIPTION
FileNotFoundException error is thrown when deploying wso2das-msf4j-tracing capp