### PR TITLE
Resolve #283 Added back the snakeyaml dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,10 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
 
 
         <dependency>

--- a/poms/msf4j-service/pom.xml
+++ b/poms/msf4j-service/pom.xml
@@ -519,10 +519,6 @@
                     <artifactId>org.wso2.carbon.runtime.feature</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.wso2.orbit.org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.wso2.carbon</groupId>
                     <artifactId>org.wso2.carbon.kernel.feature</artifactId>
                 </exclusion>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -385,6 +385,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${org.snakeyaml.version}</version>
+            </dependency>
             <!-- Metrics Dependencies - Start -->
             <dependency>
                 <groupId>org.wso2.carbon.metrics</groupId>

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -63,6 +63,10 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-xml</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
When refactoring swagger support as a separate dependency, snakeyaml dependency gets missed. Previously this was provided as a transitive dependency with swagger.io. 