### PR TITLE
Supporting http request args in Interceptor level

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/ServiceMethodInfo.java
+++ b/core/src/main/java/org/wso2/msf4j/ServiceMethodInfo.java
@@ -18,6 +18,7 @@ package org.wso2.msf4j;
 
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -28,12 +29,14 @@ public class ServiceMethodInfo {
 
     private final String methodName;
     private final Method method;
+    private Object[] args;
 
     private Map<String, Object> attributes = new ConcurrentHashMap<>();
 
-    public ServiceMethodInfo(String methodName, Method method) {
+    public ServiceMethodInfo(String methodName, Method method, Object[] args) {
         this.methodName = methodName;
         this.method = method;
+        this.args = Arrays.copyOf(args, args.length);;
     }
 
     public String getMethodName() {
@@ -42,6 +45,10 @@ public class ServiceMethodInfo {
 
     public Method getMethod() {
         return method;
+    }
+
+    public Object[] getArgs() {
+        return Arrays.copyOf(args, args.length);
     }
 
     /**

--- a/core/src/main/java/org/wso2/msf4j/internal/InterceptorExecutor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/InterceptorExecutor.java
@@ -22,7 +22,7 @@ import org.wso2.msf4j.Interceptor;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.Response;
 import org.wso2.msf4j.ServiceMethodInfo;
-import org.wso2.msf4j.internal.router.HttpResourceModel;
+import org.wso2.msf4j.internal.router.HttpMethodInfo;
 
 import java.util.List;
 
@@ -38,15 +38,15 @@ public class InterceptorExecutor {
     private List<Interceptor> interceptors;
     private ServiceMethodInfo serviceMethodInfo;
 
-    public InterceptorExecutor(HttpResourceModel httpResourceModel,
+    public InterceptorExecutor(HttpMethodInfo methodInfo,
                                Request request,
                                Response response,
                                List<Interceptor> interceptors) {
         this.request = request;
         this.response = response;
         this.interceptors = interceptors;
-        serviceMethodInfo = new ServiceMethodInfo(httpResourceModel.getMethod().getDeclaringClass().getName(),
-                httpResourceModel.getMethod());
+        serviceMethodInfo = new ServiceMethodInfo(methodInfo.getMethod().getDeclaringClass().getName(),
+                methodInfo.getMethod(), methodInfo.getArgs());
     }
 
     /**

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
@@ -116,19 +116,19 @@ public class MSF4JMessageProcessor implements CarbonMessageProcessor {
         HttpResourceModel resourceModel = destination.getDestination();
         response.setMediaType(Util.getResponseType(request.getAcceptTypes(),
                 resourceModel.getProducesMediaTypes()));
-        InterceptorExecutor interceptorExecutor = new InterceptorExecutor(resourceModel, request, response,
+
+        HttpMethodInfoBuilder httpMethodInfoBuilder =
+                new HttpMethodInfoBuilder().
+                        httpResourceModel(resourceModel).
+                        httpRequest(request).
+                        httpResponder(response).
+                        requestInfo(destination.getGroupNameValues());
+        HttpMethodInfo httpMethodInfo = httpMethodInfoBuilder.build();
+
+        InterceptorExecutor interceptorExecutor = new InterceptorExecutor(httpMethodInfo, request, response,
                                                                           currentMicroservicesRegistry
                                                                                   .getInterceptors());
         if (interceptorExecutor.execPreCalls()) { // preCalls can throw exceptions
-
-            HttpMethodInfoBuilder httpMethodInfoBuilder =
-                    new HttpMethodInfoBuilder().
-                            httpResourceModel(resourceModel).
-                            httpRequest(request).
-                            httpResponder(response).
-                            requestInfo(destination.getGroupNameValues());
-
-            HttpMethodInfo httpMethodInfo = httpMethodInfoBuilder.build();
             if (httpMethodInfo.isStreamingSupported()) {
                 while (!(request.isEmpty() && request.isEomAdded())) {
                     httpMethodInfo.chunk(request.getMessageBody());

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
@@ -323,4 +323,12 @@ public class HttpMethodInfo {
     public boolean isStreamingSupported() {
         return httpStreamHandler != null;
     }
+
+    public Object[] getArgs() {
+        return Arrays.copyOf(args, args.length);
+    }
+
+    public Method getMethod() {
+        return method;
+    }
 }


### PR DESCRIPTION
Currently in MSF4J Interceptor level, we can get the HTTP handler method which would be invoked by calling  serviceMethodInfo.getMethod().

https://github.com/wso2/msf4j/blob/v2.1.1/analytics/msf4j-analytics/src/main/java/org/wso2/msf4j/analytics/httpmonitoring/HTTPMonitoringInterceptor.java#L85

Additionally, It will be useful to have request parameters as well in order to perform various types of request validations in Interceptor level such as Bean validation and ETag validation.