### PR TITLE
Sending response message to client if an interceptor returns false

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
@@ -138,6 +138,9 @@ public class MSF4JMessageProcessor implements CarbonMessageProcessor {
                 httpMethodInfo.invoke(request, destination);
             }
             interceptorExecutor.execPostCalls(response.getStatusCode()); // postCalls can throw exceptions
+        } else {
+            // execPreCalls() returned false, send response message to the client
+            response.send();
         }
     }
 

--- a/core/src/main/java/org/wso2/msf4j/security/JWTSecurityInterceptor.java
+++ b/core/src/main/java/org/wso2/msf4j/security/JWTSecurityInterceptor.java
@@ -68,7 +68,6 @@ public class JWTSecurityInterceptor implements Interceptor {
         }
         responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, AUTH_TYPE_JWT);
         responder.setStatus(javax.ws.rs.core.Response.Status.UNAUTHORIZED.getStatusCode());
-        responder.send();
         return false;
     }
 

--- a/core/src/main/java/org/wso2/msf4j/security/basic/AbstractBasicAuthSecurityInterceptor.java
+++ b/core/src/main/java/org/wso2/msf4j/security/basic/AbstractBasicAuthSecurityInterceptor.java
@@ -57,7 +57,6 @@ public abstract class AbstractBasicAuthSecurityInterceptor implements Intercepto
         }
         responder.setStatus(javax.ws.rs.core.Response.Status.UNAUTHORIZED.getStatusCode());
         responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, AUTH_TYPE_BASIC);
-        responder.send();
         return false;
     }
 

--- a/core/src/main/java/org/wso2/msf4j/security/oauth2/OAuth2SecurityInterceptor.java
+++ b/core/src/main/java/org/wso2/msf4j/security/oauth2/OAuth2SecurityInterceptor.java
@@ -194,16 +194,10 @@ public class OAuth2SecurityInterceptor implements Interceptor {
                 errorCode == SecurityErrorCode.INVALID_AUTHORIZATION_HEADER) {
             responder.setStatus(javax.ws.rs.core.Response.Status.UNAUTHORIZED.getStatusCode());
             responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, AUTH_TYPE_OAUTH2);
-            responder.send();
         } else if (errorCode == SecurityErrorCode.AUTHORIZATION_FAILURE) {
             responder.setStatus(javax.ws.rs.core.Response.Status.FORBIDDEN.getStatusCode());
-            responder.send();
         } else {
             responder.setStatus(javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
-            responder.send();
         }
-
     }
-
-
 }

--- a/core/src/test/java/org/wso2/msf4j/interceptor/TestInterceptor.java
+++ b/core/src/test/java/org/wso2/msf4j/interceptor/TestInterceptor.java
@@ -50,7 +50,6 @@ public class TestInterceptor implements Interceptor {
         String header = request.getHeader("X-Request-Type");
         if (header != null && header.equals("Reject")) {
             responder.setStatus(javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE.getStatusCode());
-            responder.send();
             return false;
         }
 

--- a/samples/jwt-claims/jwt-sample/src/main/java/org/wso2/msf4j/example/CustomJWTClaimsInterceptor.java
+++ b/samples/jwt-claims/jwt-sample/src/main/java/org/wso2/msf4j/example/CustomJWTClaimsInterceptor.java
@@ -53,7 +53,6 @@ public class CustomJWTClaimsInterceptor implements Interceptor {
         }
         responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, AUTH_TYPE_JWT);
         responder.setStatus(javax.ws.rs.core.Response.Status.UNAUTHORIZED.getStatusCode());
-        responder.send();
         return false;
     }
 


### PR DESCRIPTION
With the current implementation interceptors need to specifically invoke response.send() method for sending the response message back to the client:

```java
public abstract class AbstractBasicAuthSecurityInterceptor implements Interceptor {
    ...

    @Override
    public boolean preCall(Request request, Response responder, ServiceMethodInfo serviceMethodInfo) throws Exception {
        ...
        responder.setStatus(javax.ws.rs.core.Response.Status.UNAUTHORIZED.getStatusCode());
        responder.setHeader(javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE, AUTH_TYPE_BASIC);
        responder.send();
        return false;
    }
    ...
}
```

This pull request improves this logic by invoking response.send() method in MSF4JMessageProcessor.dispatchMethod() if an interceptor returns false when Interceptor.preCall() is invoked.