### PR TITLE
Fix headings & build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://wso2.org/jenkins/job/msf4j/badge/icon)](https://wso2.org/jenkins/job/msf4j)
+[Build status:](https://wso2.org/jenkins/job/products/job/msf4j/) ![Build Status](https://wso2.org/jenkins/job/products/job/msf4j/badge/icon)
 
-#WSO2 Microservices Framework for Java (MSF4J)
+# WSO2 Microservices Framework for Java (MSF4J)
 
 WSO2 Microservices Framework for Java (MSF4J) is a lightweight high performance framework for developing
 & running microservices.
@@ -30,7 +30,7 @@ Tests were run out of the box without any tuning on 32 core 64GB server in JVM v
 
 More details about the performance test can found [here](perf-benchmark).
 
-##Hello world with MSF4J
+## Hello world with MSF4J
 
 It is really easy to define & deploy a Java microservice using WSO2 MSF4J. 
 You simply need to annotate your service and deploy it using a single line of code. 
@@ -51,7 +51,7 @@ mvn archetype:generate -DarchetypeGroupId=org.wso2.msf4j \
 This will generate a project structure for you to quickly get started.
 Next navigate to the Hello-Service directory. You will find a pom.xml file and also an src directory.
 
-####pom.xml
+#### pom.xml
 This pom file inherits from the msf4j-service/pom.xml. It provides a way of setting things up quickly with minimum 
 amount of 
 configuration. Click [here](poms/msf4j-service) for more information.
@@ -82,7 +82,7 @@ configuration. Click [here](poms/msf4j-service) for more information.
 
 You don't need to change anything in this pom.xml file.
 
-####HelloService.java
+#### HelloService.java
 Change the org.example.service.HelloService class as follows to echo back the name input parameter. 
 You can remove the auto generated code and replace it with the following code segment:
 
@@ -105,7 +105,7 @@ public class HelloService {
 }
 ```
 
-####Application.java
+#### Application.java
 This is the one-liner to deploy your service using WSO2 MSF4J.
 ```java
 public class Application {
@@ -118,21 +118,21 @@ public class Application {
 ```
 
 
-###Build the Service
+### Build the Service
 Run the following Maven command. This will create the fat jar **Hello-Service-0.1-SNAPSHOT.jar** in the **target** directory.
 ```
 mvn package
 ```
 This fat jar is a jar file that contains your microservice as well as all its dependencies.
 
-###Run the Service
+### Run the Service
 You just have to run the following command to get your service up and running.
 ```
 java -jar target/Hello-Service-*.jar
 ```
 
 
-###Test the Service with cURL
+### Test the Service with cURL
 Run the following command or simply go to [http://localhost:8080/hello/wso2]
 (http://localhost:8080/hello/wso2) from your browser.
 ```
@@ -141,59 +141,60 @@ curl http://localhost:8080/hello/wso2
 
 You should see a response that prints "Hello wso2"
 
-##Supported Annotations
+## Supported Annotations
 
 In this section, we will look at the annotations used in MSF4J microservices. As you may have already noticed,
  we support a subset of the JAXRS annotations.
 
-###Class level annotations
-#####@Path
+### Class level annotations
+##### @Path
 Root path for resource methods. All the paths specified in the resource methods will be sub paths of this.
 
-#####@Consumes
+##### @Consumes
 Default consume media type(s) for resource methods. The resource methods that do not specify @Consume annotation will
  inherit this consume media type(s).
 
-#####@Produces
+##### @Produces
 Default produce media type(s) for resource methods. The resource methods that do not specify @Produce annotation will
 inherit this produce media type(s).
 
 
-###Method level annotations
-#####@Path
+### Method level annotations
+##### @Path
 Endpoint of the resource method relative to @Path of the container resource class.
 
-#####@Consumes
+##### @Consumes
 Media type(s) that the method can consume. This overrides the class level @Consumes media types.
 
-#####@Produces
+##### @Produces
 Media type(s) that is produced by the method. This overrides the class level @Produces media types.
 
-#####@GET
+##### @GET
 HTTP GET method. Specify that the resource method supports HTTP GET method.
 
-#####@PUT
+##### @PUT
 HTTP PUT method. Specify that the resource method supports HTTP PUT method.
 
-#####@POST
+##### @POST
 HTTP POST method. Specify that the resource method supports HTTP POST method.
 
-#####@DELETE
+##### @DELETE
 HTTP DELETE method. Specify that the resource method supports HTTP DELETE method.
 
-#####@HEAD
+##### @HEAD
 HTTP HEAD method. Specify that the resource method supports HTTP HEAD method.
 
-#####@OPTIONS
+##### @OPTIONS
 HTTP OPTIONS method. Specify that the resource method supports HTTP OPTIONS method.
 
-###Parameter level annotations
-#####@DefaultValue
+### Parameter level annotations
+##### @DefaultValue
 Specify a default value for a resource method parameter. The value will be automatically converted to the 
 corresponding parameter's type.
 
-#####@Context
-Inject additional objects to a resource method. Currently supports injection of  following objects.
+##### @Context
+Inject additional objects to a resource method. Currently supports injection of the following objects.
+
 * org.wso2.msf4j.Request - 
     This object can be used to access properties of the HTTP request. The transport session (org.wso2.msf4j.Session) 
     can also be accessed via org.wso2.msf4j.Request#getSession(). 
@@ -209,37 +210,37 @@ Inject additional objects to a resource method. Currently supports injection of 
     This object can be used to stream a HTML form submission request body and process it while the request is streaming. 
     See the [FormParam](samples/formparam) sample.
 
-#####@PathParam
+##### @PathParam
 /StockQuote/{symbol} to get value of symbol. The value will be automatically converted to the corresponding parameter
  type and assigned to that parameter.
 
-#####@QueryParam
+##### @QueryParam
 /Students?age=18 to get value of age. The value will be automatically converted to the corresponding parameter type 
 and assigned to that parameter.
 
-#####@HeaderParam
+##### @HeaderParam
 To read HTTP request header values. The value will be automatically converted to the corresponding parameter type and
  assigned to that parameter.
  
-#####@CookieParam
+##### @CookieParam
 Extracts the value from the specified cookie, converts to the corresponding parameter type and assigns the value to 
 that parameter.  
 
-#####@FormParam
+##### @FormParam
 To support HTML form submission with application/x-www-form-urlencoded and multipart/form-data The value will be 
 automatically converted to the corresponding parameter type and assigned to that parameter
 
-#####@FormDataParam
+##### @FormDataParam
 To support complex form submission with multipart/form-data content type. E.g file uploads and beans. The values will be 
 automatically converted to the corresponding parameter type and assigned to that parameter
 
-###Lifecycle Callback Methods
+### Lifecycle Callback Methods
 Support following Java lifecycle callback method annotations. 
 
-#####@PostConstruct
+##### @PostConstruct
 Invoke by the container on newly constructed service instances after all dependency injection has completed and before transport starts. 
 
-#####@PreDestroy
+##### @PreDestroy
 Invoke by the container during server shutdown before the  container removes the service instance.
 
 For a detailed example, check out the lifecycle sample [here](https://github.com/wso2/msf4j/tree/master/samples/lifecycle).
@@ -253,7 +254,7 @@ Please do refer the following for complete instructions.
 * [MSF4J Interceptors - Deployable Jar mode instructions ](/samples/interceptor/deployable-jar-interceptor-service/README.md)
 * [MSF4J Interceptors - OSGi mode instructions](/samples/interceptor/osgi-interceptor-service/README.md)
 
-##Develop and configure MSF4J services using Spring framework
+## Develop and configure MSF4J services using Spring framework
 
 Spring is a popular Java application development framework which supports concepts like Dependency Injection(DI) 
 and Convention over Configuration.  Spring support for MSF4J provides following features. 
@@ -289,7 +290,7 @@ For further details refer Spring [Helloworld sample](samples/spring-helloworld).
 
 
 
-##Annotations for Analytics
+## Annotations for Analytics
 
 In this section, we will look at the annotations available for analytics purposes MSF4J microservices. There are annotations 
 for Metrics and HTTP Monitoring.
@@ -301,7 +302,7 @@ The Metrics data will be published to WSO2 DAS periodically. However the HTTP Mo
 
 For a detailed example, check out the [Metrics and HTTP Monitoring sample](samples/http-monitoring). 
 
-###Metrics Annotations
+### Metrics Annotations
 
 You can use the Metrics annnotations in your MSF4J microservices to understand how your microservices work in production.
 
@@ -326,35 +327,34 @@ You can also configure a level in Metrics Annotations. For more information abou
 see [WSO2 Carbon Metrics](https://github.com/wso2/carbon-metrics). In MSF4J, you can load the metrics level configuration 
 via the System Property named `metrics.level.conf`.
 
-#####@Counted
+##### @Counted
 Count the method invocations. There is a parameter named "monotonic" and it is set to false by default. This means that the
 counter is decremented when the method returns. This is useful to count the current invocations of the annotated method.
 
 Use `@Counted(monotonic = true)` when you want the counter to increase monotonically. This is useful to count the total invocations 
 of the annotated method
 
-#####@Metered
+##### @Metered
 Measure the rate of method invocations. This also keeps a count of the total invocations of the annotated method.
 
-#####@Timed
+##### @Timed
 Maintain a histogram of durations of each method invocation. This also measures the rate of method invocations and keeps a count of the 
 total invocations of the annotated method. 
 
-###HTTP Monitoring Annotation
+### HTTP Monitoring Annotation
 
 You can use the annotation provided for HTTP Monitoring when you want to monitor each HTTP request and see the summary 
 in "HTTP Monitoring Dashboard".
 
-#####@HTTPMonitored
+##### @HTTPMonitored
 Monitor each HTTP request. This annotation can be used at the Class level and the Method level.
 
-###HTTP Message Tracing
+### HTTP Message Tracing
 MSF4J supports visual message tracing through user friendly dashboards in WSO2 DAS or Zipkin. MSF4J message tracing provides 
 a detailed insight to the complex microservices interactions in a system making monitoring, trouble shooting and optimization of 
 microservices very easy. Please check [WSO2 DAS Tracing](samples/message-tracing/das) and [Zipkin Tracing](samples/message-tracing/zipkin) samples for more details.
 
-
-###Swagger Annotations
+### Swagger Annotations
 [Swagger](http://swagger.io/getting-started/) is a standard, language-agnostic interface to REST APIs which allows both 
 humans and computers to discover and understand the capabilities of the service without access to source code, documentation, 
 or through network traffic inspection. 
@@ -398,7 +398,7 @@ new MicroservicesRunner().addExceptionMapper(new SymbolNotFoundMapper(), new Dup
 Nygard's circuit breaker pattern is supported in MSF4J using the Netflix Hystrix library. For more details see the
 [circuit breaker sample](samples/circuitbreaker)
 
-###Complete Feature List
+### Complete Feature List
 * Annotation based definition of microservices
 * High performance Netty based transport
 * WSO2 Developer Studio based tooling for microservices development starting from a Swagger API definition


### PR DESCRIPTION
You must have a space between the final # character and the heading text to create headings. 

The build status icon was pointing to the wrong location and was not formatted correctly.