### PR TITLE
Update carbon-transport version

### DIFF
--- a/core/src/test/java/org/wso2/msf4j/util/client/websocket/WebSocketClient.java
+++ b/core/src/test/java/org/wso2/msf4j/util/client/websocket/WebSocketClient.java
@@ -32,7 +32,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
@@ -177,12 +177,12 @@ public class WebSocketClient {
      *
      * @param buf content of the pong message to be sent.
      */
-    public void sendPong(ByteBuffer buf) {
+    public void sendPing(ByteBuffer buf) {
         if (channel == null) {
             log.error("Channel is null, cannot write data.");
             throw new NullPointerException("Cannot find the channel to write");
         }
-        channel.writeAndFlush(new PongWebSocketFrame(Unpooled.wrappedBuffer(buf)));
+        channel.writeAndFlush(new PingWebSocketFrame(Unpooled.wrappedBuffer(buf)));
     }
 
     /**

--- a/core/src/test/java/org/wso2/msf4j/websocket/DeploymentTest.java
+++ b/core/src/test/java/org/wso2/msf4j/websocket/DeploymentTest.java
@@ -81,12 +81,12 @@ public class DeploymentTest {
         Assert.assertEquals(bufferReceived, bufferSent);
 
         //Test the Pong Message
-        byte[] pongBytes = {6, 7, 8, 9, 10};
-        ByteBuffer pongBufferSent = ByteBuffer.wrap(pongBytes);
-        echoClient.sendPong(pongBufferSent);
+        byte[] pingBytes = {6, 7, 8, 9, 10};
+        ByteBuffer pingBufferSent = ByteBuffer.wrap(pingBytes);
+        echoClient.sendPing(pingBufferSent);
         Thread.sleep(sleepTime);
         ByteBuffer pongBufferReceived = echoClient.getBufferReceived();
-        Assert.assertEquals(pongBufferReceived, pongBufferSent);
+        Assert.assertEquals(pongBufferReceived, pingBufferSent);
 
         //Closing the connection
         echoClient.shutDown();

--- a/core/src/test/java/org/wso2/msf4j/websocket/ValidatorTest.java
+++ b/core/src/test/java/org/wso2/msf4j/websocket/ValidatorTest.java
@@ -42,9 +42,9 @@ import org.wso2.msf4j.websocket.exception.WebSocketMethodParameterException;
 /**
  * Test the Exceptions which can be occurred when deploying and running WebSocket.
  */
-public class ValidatorTesting {
+public class ValidatorTest {
 
-    private static final Logger log = LoggerFactory.getLogger(ValidatorTesting.class);
+    private static final Logger log = LoggerFactory.getLogger(ValidatorTest.class);
     private EndpointValidator validator = new EndpointValidator();
 
     @BeforeClass

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -72,7 +72,7 @@ limitations under the License.
 
     <test name="session-unit-tests" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.msf4j.websocket.ValidatorTesting"/>
+            <class name="org.wso2.msf4j.websocket.ValidatorTest"/>
             <class name="org.wso2.msf4j.websocket.EndpointRegistryTest"/>
             <class name="org.wso2.msf4j.websocket.DeploymentTest"/>
         </classes>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -627,7 +627,7 @@
         <carbon.deployment.version.range>[5.0.0,6.0.0)</carbon.deployment.version.range>
         <carbon.messaging.version>2.3.0</carbon.messaging.version>
         <carbon.messaging.version.range>[2,3)</carbon.messaging.version.range>
-        <org.wso2.carbon.transport.http.netty.version>4.3.0-m2</org.wso2.carbon.transport.http.netty.version>
+        <org.wso2.carbon.transport.http.netty.version>4.4.0</org.wso2.carbon.transport.http.netty.version>
         <org.wso2.carbon.transport.http.netty.version.range>[4.0,5)</org.wso2.carbon.transport.http.netty.version.range>
         <org.apache.httpcomponents.httpclient.version>4.5.2</org.apache.httpcomponents.httpclient.version>
         <msf4j.version>2.3.0-SNAPSHOT</msf4j.version>


### PR DESCRIPTION
Update MSF4J to new carbon-transport 4.4.0 and fix issues of test cases in WebSocket