### PR TITLE
Move MessageProcessor registration logic to SC

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
@@ -17,7 +17,6 @@
 package org.wso2.msf4j.internal;
 
 import org.apache.commons.io.FileUtils;
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigProviderFactory;
@@ -86,11 +85,6 @@ import static org.wso2.msf4j.internal.MSF4JConstants.WEBSOCKET_UPGRADE;
 /**
  * Process carbon messages for MSF4J.
  */
-@Component(
-        name = "org.wso2.msf4j.internal.MSF4JMessageProcessor",
-        immediate = true,
-        service = CarbonMessageProcessor.class
-)
 public class MSF4JMessageProcessor implements CarbonMessageProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(MSF4JMessageProcessor.class);

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.kernel.startupresolver.StartupServiceUtils;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
 import org.wso2.carbon.messaging.ServerConnector;
 import org.wso2.msf4j.DefaultSessionManager;
 import org.wso2.msf4j.Interceptor;
@@ -349,6 +350,8 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
             isAllRequiredCapabilitiesAvailable = true;
         }
 
+        DataHolder.getInstance().getBundleContext()
+                  .registerService(CarbonMessageProcessor.class, new MSF4JMessageProcessor(), null);
         DataHolder.getInstance().getBundleContext().registerService(MicroservicesServerSC.class, this, null);
         log.info("All microservices are available");
     }


### PR DESCRIPTION
At the moment, there is a chance of MessageProcessor getting initialized before a ConfigProvider service reference. Need to make sure that ConfigProvider service reference gets registered first and then we initialize the MessageProcessor. Therefore this move the MSF4JMessageProcessor registration logic to MicroservicesSC.
Resolves #442 