### PR TITLE
Fix issue of can't remove existing services

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
@@ -92,8 +92,14 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
     }
 
     public void removeService(Object service) {
-        services.remove(service);
-        updateMetadata();
+        Path path = service.getClass().getAnnotation(Path.class);
+        if (path != null) {
+            services.remove(path.value());
+            updateMetadata();
+        } else {
+            log.warn("Service removal failed. Microservice class '" + service.getClass().getName() +
+                     "' doesn't contain a root Path.");
+        }
     }
 
     public void setSessionManager(SessionManager sessionManager) {
@@ -199,7 +205,6 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
                 findFirst().
                 flatMap(entry -> Optional.ofNullable(entry.getValue()));
     }
-
 
     public void removeExceptionMapper(ExceptionMapper em) {
         Arrays.stream(em.getClass().getMethods()).

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
@@ -92,14 +92,18 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
     }
 
     public void removeService(Object service) {
+        if (service == null) {
+            log.error("Service cannot be null.");
+            return;
+        }
         Path path = service.getClass().getAnnotation(Path.class);
-        if (path != null) {
-            services.remove(path.value());
-            updateMetadata();
-        } else {
+        if (path == null) {
             log.warn("Service removal failed. Microservice class '" + service.getClass().getName() +
                      "' doesn't contain a root Path.");
+            return;
         }
+        services.remove(path.value());
+        updateMetadata();
     }
 
     public void setSessionManager(SessionManager sessionManager) {

--- a/core/src/test/java/org/wso2/msf4j/internal/MicroservicesRegistryTest.java
+++ b/core/src/test/java/org/wso2/msf4j/internal/MicroservicesRegistryTest.java
@@ -1,0 +1,90 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.msf4j.internal;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.msf4j.MicroservicesRunner;
+import org.wso2.msf4j.exception.MappedException;
+import org.wso2.msf4j.exception.MappedException2;
+import org.wso2.msf4j.exception.TestExceptionMapper;
+import org.wso2.msf4j.exception.TestExceptionMapper2;
+import org.wso2.msf4j.interceptor.RequestInterceptor;
+import org.wso2.msf4j.interceptor.ResponseInterceptor;
+import org.wso2.msf4j.interceptor.TestInterceptor;
+import org.wso2.msf4j.interceptor.TestInterceptorDeprecated;
+import org.wso2.msf4j.service.SecondService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class MicroservicesRegistryTest {
+
+    private MicroservicesRunner microservicesRunner = new MicroservicesRunner();
+    private SecondService service = new SecondService();
+    private TestExceptionMapper exceptionMapper1 = new TestExceptionMapper();
+    private TestExceptionMapper2 exceptionMapper2 = new TestExceptionMapper2();
+    private TestInterceptor interceptor1 = new TestInterceptor();
+    private TestInterceptorDeprecated interceptor2 = new TestInterceptorDeprecated();
+
+    @BeforeClass
+    public void setup() {
+        microservicesRunner.getMsRegistry().addService(service);
+        microservicesRunner.getMsRegistry().addInterceptor(interceptor1, interceptor2);
+        microservicesRunner.getMsRegistry().addExceptionMapper(exceptionMapper1, exceptionMapper2);
+    }
+
+    @Test
+    public void testMicroservicesRegistry() {
+        MicroservicesRegistryImpl msRegistry = microservicesRunner.getMsRegistry();
+        Optional<Map.Entry<String, Object>> serviceWithBasePath = msRegistry.getServiceWithBasePath("/SecondService");
+        assertTrue(serviceWithBasePath.isPresent());
+        assertEquals(msRegistry.getHttpServices().size(), 1);
+        assertEquals(msRegistry.getServiceCount(), 1);
+        assertTrue(msRegistry.getHttpServices().contains(service));
+        msRegistry.removeService(service);
+        serviceWithBasePath = msRegistry.getServiceWithBasePath("/SecondService");
+        assertFalse(serviceWithBasePath.isPresent());
+
+        List<RequestInterceptor> globalRequestInterceptorList = msRegistry.getGlobalRequestInterceptorList();
+        assertEquals(globalRequestInterceptorList.size(), 2);
+        assertEquals(globalRequestInterceptorList.get(0), interceptor1);
+        List<ResponseInterceptor> globalResponseInterceptorList = msRegistry.getGlobalResponseInterceptorList();
+        assertEquals(globalResponseInterceptorList.size(), 2);
+        assertEquals(globalResponseInterceptorList.get(0), interceptor1);
+        msRegistry.removeInterceptor(interceptor1);
+        assertEquals(msRegistry.getGlobalRequestInterceptorList().size(), 1);
+        assertEquals(msRegistry.getGlobalResponseInterceptorList().size(), 1);
+        msRegistry.removeGlobalRequestInterceptor(interceptor2);
+        assertEquals(msRegistry.getGlobalRequestInterceptorList().size(), 0);
+        assertEquals(msRegistry.getGlobalResponseInterceptorList().size(), 1);
+        msRegistry.removeGlobalResponseInterceptor(interceptor2);
+        assertEquals(msRegistry.getGlobalRequestInterceptorList().size(), 0);
+        assertEquals(msRegistry.getGlobalResponseInterceptorList().size(), 0);
+
+        assertTrue(msRegistry.getExceptionMapper(new MappedException()).isPresent());
+        assertTrue(msRegistry.getExceptionMapper(new MappedException2()).isPresent());
+        msRegistry.removeExceptionMapper(exceptionMapper1);
+        //TODO this assertion get fail when enable coverage. Need to check why
+        assertFalse(msRegistry.getExceptionMapper(new MappedException()).isPresent());
+        assertTrue(msRegistry.getExceptionMapper(new MappedException2()).isPresent());
+    }
+}

--- a/core/src/test/java/org/wso2/msf4j/internal/MicroservicesRegistryTest.java
+++ b/core/src/test/java/org/wso2/msf4j/internal/MicroservicesRegistryTest.java
@@ -36,6 +36,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * Test class to validate the MicroservicesRegistry.
+ */
 public class MicroservicesRegistryTest {
 
     private MicroservicesRunner microservicesRunner = new MicroservicesRunner();
@@ -52,6 +55,9 @@ public class MicroservicesRegistryTest {
         microservicesRunner.getMsRegistry().addExceptionMapper(exceptionMapper1, exceptionMapper2);
     }
 
+    /**
+     * Test the basic functionality of MicroservicesRegistry.
+     */
     @Test
     public void testMicroservicesRegistry() {
         MicroservicesRegistryImpl msRegistry = microservicesRunner.getMsRegistry();

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -84,4 +84,10 @@ limitations under the License.
         </classes>
     </test>
 
+    <test name="new unit tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.msf4j.internal.MicroservicesRegistryTest"/>
+        </classes>
+    </test>
+
 </suite>

--- a/deployer/src/main/java/org/wso2/msf4j/deployer/internal/MicroservicesDeployer.java
+++ b/deployer/src/main/java/org/wso2/msf4j/deployer/internal/MicroservicesDeployer.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.Path;
 
 /**
  * Implementation of the micro service deployer.
@@ -217,7 +216,7 @@ public class MicroservicesDeployer implements Deployer {
         }
 
         microservicesRegistries.values().forEach(registry -> {
-            registry.removeService(service.getClass().getAnnotation(Path.class).value());
+            registry.removeService(service);
             registry.preDestroyService(service);
         });
         log.info("Microservice {} undeployed successfully", service.getClass().getName());


### PR DESCRIPTION
## Purpose
Resolves #474 

## Goals
This will fix the issue of users can't remove the already added services from the MicroservicesRegistry

## Approach
Instead of directly passing the service object to remove method, we need to get the Path value and use that to remove the existing service.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Add org.wso2.msf4j.internal.MicroservicesRegistryTest to test the MicroservicesRegistry functionalities
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_40, Ubuntu 14.04
 
## Learning
N/A