### PR TITLE
Fix MSF4J Spring register interceptors as global only

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Please do refer the following for complete instructions.
 * [MSF4J Interceptors - Stand alone mode instructions](/samples/interceptor/fatjar-interceptor-service/README.md)
 * [MSF4J Interceptors - Deployable Jar mode instructions ](/samples/interceptor/deployable-jar-interceptor-service/README.md)
 * [MSF4J Interceptors - OSGi mode instructions](/samples/interceptor/osgi-interceptor-service/README.md)
+* [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](/samples/interceptor/spring-fatjar-interceptor-service/README.md)
 
 ## Develop and configure MSF4J services using Spring framework
 

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -134,7 +134,6 @@ public class MicroservicesRunner {
      * @param requestInterceptor interceptor instances
      */
     public MicroservicesRunner addGlobalRequestInterceptor(RequestInterceptor... requestInterceptor) {
-        checkState();
         msRegistry.addGlobalRequestInterceptor(requestInterceptor);
         return this;
     }
@@ -145,7 +144,6 @@ public class MicroservicesRunner {
      * @param responseInterceptor interceptor instances
      */
     public MicroservicesRunner addGlobalResponseInterceptor(ResponseInterceptor... responseInterceptor) {
-        checkState();
         msRegistry.addGlobalResponseInterceptor(responseInterceptor);
         return this;
     }
@@ -159,7 +157,6 @@ public class MicroservicesRunner {
      * @deprecated
      */
     public MicroservicesRunner addInterceptor(Interceptor... interceptor) {
-        checkState();
         msRegistry.addGlobalRequestInterceptor(interceptor);
         msRegistry.addGlobalResponseInterceptor(interceptor);
         return this;

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JMessageProcessor.java
@@ -217,6 +217,7 @@ public class MSF4JMessageProcessor implements CarbonMessageProcessor {
                 .getDestinationMethod(request.getUri(), request.getHttpMethod(), request.getContentType(),
                         request.getAcceptTypes());
         HttpResourceModel resourceModel = destination.getDestination();
+        request.setProperty(MSF4JConstants.METHOD_PROPERTY_NAME, resourceModel.getMethod()); // Required for analytics
         response.setMediaType(Util.getResponseType(request.getAcceptTypes(), resourceModel.getProducesMediaTypes()));
         HttpMethodInfoBuilder httpMethodInfoBuilder = new HttpMethodInfoBuilder()
                 .httpResourceModel(resourceModel)

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
@@ -23,7 +23,6 @@ import org.wso2.msf4j.HttpStreamer;
 import org.wso2.msf4j.Request;
 import org.wso2.msf4j.Response;
 import org.wso2.msf4j.interceptor.InterceptorExecutor;
-import org.wso2.msf4j.internal.MSF4JConstants;
 import org.wso2.msf4j.internal.MicroservicesRegistryImpl;
 
 import java.lang.reflect.InvocationTargetException;
@@ -171,7 +170,6 @@ public class HttpMethodInfo {
             PatternPathRouter.RoutableDestination<HttpResourceModel> destination, HttpMethodInfo httpMethodInfo,
             Request request, MicroservicesRegistryImpl microservicesRegistry, boolean isSubResource) throws Exception {
         Class<?> clazz = httpMethodInfo.method.getDeclaringClass();
-        request.setProperty(MSF4JConstants.METHOD_PROPERTY_NAME, httpMethodInfo.method); // Required for analytics
 
         // Execute global request interceptors if not a sub-resource (global interceptors will only be executed
         // at the parent resource

--- a/core/src/test/java/org/wso2/msf4j/InterceptorTestBase.java
+++ b/core/src/test/java/org/wso2/msf4j/InterceptorTestBase.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * Base class for testing interceptors.
  */
-abstract class InterceptorTestBase {
+public abstract class InterceptorTestBase {
 
     private final Gson gson = new Gson();
     protected static URI baseURI;
@@ -143,7 +143,7 @@ abstract class InterceptorTestBase {
      * @return http url connection instance
      * @throws IOException on error creating http url connection
      */
-    private HttpURLConnection createHttpUrlConnection(String path, String method, boolean keepAlive,
+    protected HttpURLConnection createHttpUrlConnection(String path, String method, boolean keepAlive,
                                                       Map<String, String> headers) throws IOException {
         URL url = baseURI.resolve(path).toURL();
         HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();

--- a/samples/interceptor/README.md
+++ b/samples/interceptor/README.md
@@ -1,9 +1,10 @@
-#Applying interceptors
+# Applying interceptors
 
 * Please refer [MSF4J Interceptors - Common](../interceptor/interceptor-common) for writing request and response interceptors
 * Please refer [MSF4J Interceptor Service - Fat Jar mode](../interceptor/fatjar-interceptor-service) for using interceptors in fat jar mode
 * Please refer [MSF4J Interceptor Service - Deployable Jar mode](../interceptor/deployable-jar-interceptor-service) for using interceptors in deployable jar mode
 * Please refer [MSF4J Interceptor Service - OSGi mode](../interceptor/osgi-interceptor-service) for using interceptors in OSGi mode
+* Please refer [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](../spring-fatjar-interceptor-service) for using interceptors with MSF4J Spring in fat jar mode
 
 # Priority order of Interceptors
 

--- a/samples/interceptor/deployable-jar-interceptor-service/README.md
+++ b/samples/interceptor/deployable-jar-interceptor-service/README.md
@@ -4,6 +4,7 @@ This sample demonstrates how to create deployable interceptors for hot deploymen
 
 * See also; [MSF4J Interceptor Service - Fat Jar mode](../fatjar-interceptor-service)
 * See also; [MSF4J Interceptor Service - OSGi mode](../osgi-interceptor-service)
+* See also; [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](../spring-fatjar-interceptor-service)
 
 ```java
 @Path("/interceptor-service")

--- a/samples/interceptor/fatjar-interceptor-service/README.md
+++ b/samples/interceptor/fatjar-interceptor-service/README.md
@@ -5,6 +5,7 @@ and running it in a Java process is also referred to as server-less execution.
 
 * See also; [MSF4J Interceptor Service - Deployable Jar mode](../deployable-jar-interceptor-service)
 * See also; [MSF4J Interceptor Service - OSGi mode](../osgi-interceptor-service)
+* See also; [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](../spring-fatjar-interceptor-service)
 
 ## Writing the pom.xml 
 

--- a/samples/interceptor/osgi-interceptor-service/README.md
+++ b/samples/interceptor/osgi-interceptor-service/README.md
@@ -4,6 +4,7 @@ This sample demonstrates how to create MSF4J interceptors as an OSGi bundle.
 
 * See also; [MSF4J Interceptor Service - Fat Jar mode](../fatjar-interceptor-service)
 * See also; [MSF4J Interceptor Service - Deployable Jar mode](../deployable-jar-interceptor-service)
+* See also; [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](../spring-fatjar-interceptor-service)
 
 In this sample we have exposed the InterceptorService as an OSGi service that implements 
 org.wso2.msf4j.Microservice interface as shown in the following code.

--- a/samples/interceptor/spring-fatjar-interceptor-service/README.md
+++ b/samples/interceptor/spring-fatjar-interceptor-service/README.md
@@ -1,0 +1,74 @@
+# Request and response interceptors MSF4J Spring fat jar Sample
+
+A fat jar is a jar file which includes all the dependencies in one fat (uber) jar. This mode of creating a fat jar
+and running it in a Java process is also referred to as server-less execution.
+
+* See also; [MSF4J Interceptor Service - Fat Jar mode](../fatjar-interceptor-service)
+* See also; [MSF4J Interceptor Service - Deployable Jar mode](../deployable-jar-interceptor-service)
+* See also; [MSF4J Interceptor Service - OSGi mode](../osgi-interceptor-service)
+
+## Writing the pom.xml 
+
+Your POM can inherit from [msf4j-service](../../../poms/msf4j-service). 
+See details [here](../../../poms/msf4j-service).
+
+The pom should include the following plugins
+
+```xml
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <version>${maven.reallyexecutablejarplugin.version}</version>
+                <configuration>
+                    <programFile>restinterceptor</programFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+```
+
+The pom should include the following properties
+
+```xml
+    <properties>
+        <microservice.mainClass>
+            org.wso2.msf4j.samples.springfatjarinterceptorservice.Application
+        </microservice.mainClass>
+    </properties>
+```
+
+## How to build the sample
+
+From this directory, run
+
+```
+mvn clean install
+```
+
+## How to run the sample
+
+
+Use following command to run the application
+```
+java -jar target/spring-fatjar-interceptor-service-\<version>.jar
+```
+
+## How to test the sample
+
+Use following cURL command.
+
+```
+curl http://localhost:8090/reception-service/say-hello/John
+```
+
+You should get a hello response if everything worked fine (Hello John in this case).

--- a/samples/interceptor/spring-fatjar-interceptor-service/pom.xml
+++ b/samples/interceptor/spring-fatjar-interceptor-service/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ -  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ -
+ -  WSO2 Inc. licenses this file to you under the Apache License,
+ -  Version 2.0 (the "License"); you may not use this file except
+ -  in compliance with the License.
+ -  You may obtain a copy of the License at
+ -
+ -    http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing,
+ - software distributed under the License is distributed on an
+ - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ - KIND, either express or implied.  See the License for the
+ - specific language governing permissions and limitations
+ - under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.msf4j</groupId>
+        <artifactId>msf4j-service</artifactId>
+        <version>2.4.2-SNAPSHOT</version>
+        <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.msf4j.samples</groupId>
+    <artifactId>spring-fatjar-interceptor-service</artifactId>
+    <packaging>jar</packaging>
+    <name>Sample: Spring Fat Jar Interceptor Service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.msf4j.samples</groupId>
+            <artifactId>interceptor-common</artifactId>
+            <version>${interceptor-common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.msf4j</groupId>
+            <artifactId>msf4j-spring</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <version>${maven.reallyexecutablejarplugin.version}</version>
+                <configuration>
+                    <programFile>fatjarinterceptor</programFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <interceptor-common.version>2.4.2-SNAPSHOT</interceptor-common.version>
+        <microservice.mainClass>
+            org.wso2.msf4j.samples.springfatjarinterceptorservice.Application
+        </microservice.mainClass>
+    </properties>
+</project>

--- a/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/Application.java
+++ b/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/Application.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.msf4j.samples.springfatjarinterceptorservice;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.wso2.msf4j.samples.interceptor.common.LogTextRequestInterceptor;
+import org.wso2.msf4j.samples.interceptor.common.LogTextResponseInterceptor;
+import org.wso2.msf4j.samples.interceptor.common.PropertyAddRequestInterceptor;
+import org.wso2.msf4j.samples.interceptor.common.PropertyGetResponseInterceptor;
+import org.wso2.msf4j.spring.MSF4JSpringApplication;
+
+/**
+ * Main class of starting the spring interceptor demo.
+ *
+ * @since 2.4.2
+ */
+public class Application {
+    public static void main(String[] args) {
+        MSF4JSpringApplication msf4JSpringApplication = new MSF4JSpringApplication(ReceptionService.class);
+        ConfigurableApplicationContext configurableApplicationContext =
+                MSF4JSpringApplication.run(ReceptionService.class, "--http.port=8090");
+        msf4JSpringApplication.addService(configurableApplicationContext, ReceptionService.class,
+                "/reception-service")
+                .addGlobalRequestInterceptor(new LogTextRequestInterceptor(), new PropertyAddRequestInterceptor())
+                .addGlobalResponseInterceptor(new LogTextResponseInterceptor(), new PropertyGetResponseInterceptor());
+    }
+}

--- a/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/CustomerService.java
+++ b/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/CustomerService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.msf4j.samples.springfatjarinterceptorservice;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link CustomerService} class to be injected to {@link ReceptionService} resource through Spring.
+ *
+ * @since 2.4.2
+ */
+@Component
+public class CustomerService {
+
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+}

--- a/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/ReceptionService.java
+++ b/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/ReceptionService.java
@@ -46,7 +46,6 @@ public class ReceptionService {
 
     /**
      * Method for saying hello to a customer.
-     * curl http://localhost:8080/reception-service/say-hello/John
      *
      * @return hello message for the customer
      */

--- a/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/ReceptionService.java
+++ b/samples/interceptor/spring-fatjar-interceptor-service/src/main/java/org/wso2/msf4j/samples/springfatjarinterceptorservice/ReceptionService.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.msf4j.samples.springfatjarinterceptorservice;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
+import org.wso2.msf4j.samples.interceptor.common.HTTPRequestLogger;
+import org.wso2.msf4j.samples.interceptor.common.HTTPResponseLogger;
+import org.wso2.msf4j.samples.interceptor.common.LogTextRequestInterceptor;
+import org.wso2.msf4j.samples.interceptor.common.LogTextResponseInterceptor;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Interceptor example MSF4J spring micro-service class.
+ */
+@Component
+@Path("/reception-service")
+public class ReceptionService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReceptionService.class);
+
+    @Autowired
+    private CustomerService customerService;
+
+    /**
+     * Method for saying hello to a customer.
+     * curl http://localhost:8080/reception-service/say-hello/John
+     *
+     * @return hello message for the customer
+     */
+    @GET
+    @Path("/say-hello/{name}")
+    @RequestInterceptor({HTTPRequestLogger.class, LogTextRequestInterceptor.class})
+    @ResponseInterceptor({HTTPResponseLogger.class, LogTextResponseInterceptor.class})
+    public String sayHello(@PathParam("name") String name) throws NoSuchMethodException {
+        log.info("HTTP Method Execution - " + customerService.getClass().getMethod("sayHello", String.class));
+        return customerService.sayHello(name);
+    }
+}

--- a/spring/src/main/java/org/wso2/msf4j/spring/MSF4JSpringApplication.java
+++ b/spring/src/main/java/org/wso2/msf4j/spring/MSF4JSpringApplication.java
@@ -216,20 +216,21 @@ public class MSF4JSpringApplication {
     }
 
     /**
-     * This will add a given service class to the running instnace with given base path.
+     * This will add a given service class to the running instance with given base path.
      *
      * @param configurableApplicationContext ConfigurableApplicationContext of running app
-     * @param serviceClass Service class
-     * @param basePath Base path teh servuce get registered
+     * @param serviceClass                   Service class
+     * @param basePath                       Base path to which the service get registered
      */
-    public void addService(ConfigurableApplicationContext configurableApplicationContext, Class serviceClass,
-                           String basePath) {
+    public SpringMicroservicesRunner addService(ConfigurableApplicationContext configurableApplicationContext,
+                                                Class<?> serviceClass, String basePath) {
         ClassPathBeanDefinitionScanner classPathBeanDefinitionScanner =
                 new ClassPathBeanDefinitionScanner((BeanDefinitionRegistry) configurableApplicationContext);
         classPathBeanDefinitionScanner.scan(serviceClass.getPackage().getName());
         SpringMicroservicesRunner springMicroservicesRunner =
                 configurableApplicationContext.getBean(SpringMicroservicesRunner.class);
         springMicroservicesRunner.deploy(basePath, configurableApplicationContext.getBean(serviceClass));
+        return springMicroservicesRunner;
     }
 }
 

--- a/spring/src/main/java/org/wso2/msf4j/spring/SpringMicroservicesRunner.java
+++ b/spring/src/main/java/org/wso2/msf4j/spring/SpringMicroservicesRunner.java
@@ -31,8 +31,6 @@ import org.wso2.carbon.transport.http.netty.config.TransportsConfiguration;
 import org.wso2.carbon.transport.http.netty.listener.HTTPServerConnectorProvider;
 import org.wso2.carbon.transport.http.netty.listener.ServerConnectorController;
 import org.wso2.msf4j.MicroservicesRunner;
-import org.wso2.msf4j.interceptor.RequestInterceptor;
-import org.wso2.msf4j.interceptor.ResponseInterceptor;
 import org.wso2.msf4j.internal.DataHolder;
 import org.wso2.msf4j.internal.MSF4JMessageProcessor;
 import org.wso2.msf4j.spring.transport.HTTPSTransportConfig;
@@ -74,18 +72,6 @@ public class SpringMicroservicesRunner extends MicroservicesRunner implements Ap
         for (Map.Entry<String, Object> entry : applicationContext.getBeansWithAnnotation(Path.class).entrySet()) {
             log.info("Deploying " + entry.getKey() + " bean as a resource");
             deploy(entry.getValue());
-        }
-
-        for (Map.Entry<String, RequestInterceptor> entry :
-                applicationContext.getBeansOfType(RequestInterceptor.class).entrySet()) {
-            log.info("Adding " + entry.getKey() + "  RequestInterceptor");
-            addGlobalRequestInterceptor(entry.getValue());
-        }
-
-        for (Map.Entry<String, ResponseInterceptor> entry :
-                applicationContext.getBeansOfType(ResponseInterceptor.class).entrySet()) {
-            log.info("Adding " + entry.getKey() + "  ResponseInterceptor");
-            addGlobalResponseInterceptor(entry.getValue());
         }
 
         for (Map.Entry<String, ExceptionMapper> exceptionMapper :

--- a/spring/src/test/java/org/wso2/msf4j/spring/SpringInterceptorTest.java
+++ b/spring/src/test/java/org/wso2/msf4j/spring/SpringInterceptorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.msf4j.spring;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.msf4j.InterceptorTestBase;
+import org.wso2.msf4j.conf.Constants;
+import org.wso2.msf4j.interceptor.HighPriorityGlobalRequestInterceptor;
+import org.wso2.msf4j.interceptor.HighPriorityGlobalResponseInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityGlobalRequestInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityGlobalResponseInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityGlobalRequestInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityGlobalResponseInterceptor;
+import org.wso2.msf4j.interceptor.PriorityDataHolder;
+import org.wso2.msf4j.interceptor.TestInterceptorDeprecated;
+import org.wso2.msf4j.interceptor.TestRequestInterceptor;
+import org.wso2.msf4j.interceptor.TestResponseInterceptor;
+import org.wso2.msf4j.service.SecondService;
+import org.wso2.msf4j.spring.service.second.TestMicroServiceWithDynamicPath;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Class for testing interceptors with spring.
+ *
+ * @since 2.4.2
+ */
+public class SpringInterceptorTest extends InterceptorTestBase {
+
+    private static final int port = Constants.PORT;
+    private List<ConfigurableApplicationContext> configurableApplicationContexts = new ArrayList<>();
+
+    @BeforeClass
+    public void setup() throws Exception {
+        baseURI = URI.create(String.format(Locale.ENGLISH, "http://%s:%d", Constants.HOSTNAME, port));
+        MSF4JSpringApplication msf4JSpringApplication = new MSF4JSpringApplication(SpringHttpServerTest.class);
+        configurableApplicationContexts.add(msf4JSpringApplication.run(true, "--http.port=8090"));
+        configurableApplicationContexts.add(MSF4JSpringApplication.run(SecondService.class, "--http.port=8091"));
+        msf4JSpringApplication.addService(configurableApplicationContexts.get(1), TestMicroServiceWithDynamicPath.class,
+                "/DynamicPath")
+                .addGlobalRequestInterceptor(new HighPriorityGlobalRequestInterceptor(),
+                        new MediumPriorityGlobalRequestInterceptor(), new LowPriorityGlobalRequestInterceptor())
+                .addInterceptor(new TestInterceptorDeprecated())
+                .addGlobalResponseInterceptor(new HighPriorityGlobalResponseInterceptor(),
+                        new MediumPriorityGlobalResponseInterceptor(), new LowPriorityGlobalResponseInterceptor());
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+        configurableApplicationContexts.forEach(ConfigurableApplicationContext::close);
+    }
+
+    /**
+     * Test the order and the execution of the interceptors.
+     * Order of the execution should be
+     * <p>
+     * 1) Global request interceptors according to the priority order (way developer writes them)
+     * HighPriorityGlobalRequestInterceptor -> MediumPriorityGlobalRequestInterceptor ->
+     * LowPriorityGlobalRequestInterceptor -> TestInterceptorDeprecated - [PRE CALL]
+     * <p>
+     * 2) Resource level request interceptors according to the priority order (way developer writes them)
+     * HighPriorityRRequestInterceptor -> MediumPriorityRRequestInterceptor -> LowPriorityRRequestInterceptor
+     * <p>
+     * 3) Sub-resource level request interceptors according to the priority order (way developer writes them)
+     * HighPrioritySRRequestInterceptor -> MediumPrioritySRRequestInterceptor -> LowPrioritySRRequestInterceptor
+     * <p>
+     * 4) HTTP method
+     * <p>
+     * 5) Sub-resource level response interceptors according to the priority order (way developer writes them)
+     * HighPrioritySRResponseInterceptor -> MediumPrioritySRResponseInterceptor -> LowPrioritySRResponseInterceptor
+     * <p>
+     * 6) Resource level response interceptors according to the priority order (way developer writes them)
+     * HighPriorityRResponseInterceptor -> MediumPriorityRResponseInterceptor -> LowPriorityRResponseInterceptor
+     * <p>
+     * 7) Global response interceptors according to the priority order (way developer writes them)
+     * TestInterceptorDeprecated - [POST CALL] -> HighPriorityGlobalResponseInterceptor ->
+     * MediumPriorityGlobalResponseInterceptor -> LowPriorityGlobalResponseInterceptor
+     *
+     * @throws Exception on any exception
+     */
+    @Test
+    public void springInterceptorTest() throws Exception {
+        String path = "/DynamicPath/hello/MyMicro-Service";
+        String response = doGetAndGetResponseString(path, false,
+                Collections.unmodifiableMap(Collections.emptyMap()));
+        assertEquals(response, "Hello MyMicro-Service");
+        String executionOrderString = "HighPriorityGlobalRequestInterceptor" +
+                                      "MediumPriorityGlobalRequestInterceptor" +
+                                      "LowPriorityGlobalRequestInterceptor" +
+                                      "TestInterceptorDeprecated - [PRE CALL]" +
+                                      "HighPriorityClassRequestInterceptor" +
+                                      "MediumPriorityClassRequestInterceptor" +
+                                      "LowPriorityClassRequestInterceptor" +
+                                      "HighPriorityMethodRequestInterceptor" +
+                                      "MediumPriorityMethodRequestInterceptor" +
+                                      "LowPriorityMethodRequestInterceptor" +
+                                      "[SPRING HTTP METHOD]" +
+                                      "HighPriorityMethodResponseInterceptor" +
+                                      "MediumPriorityMethodResponseInterceptor" +
+                                      "LowPriorityMethodResponseInterceptor" +
+                                      "HighPriorityClassResponseInterceptor" +
+                                      "MediumPriorityClassResponseInterceptor" +
+                                      "LowPriorityClassResponseInterceptor" +
+                                      "TestInterceptorDeprecated - [POST CALL]" +
+                                      "HighPriorityGlobalResponseInterceptor" +
+                                      "MediumPriorityGlobalResponseInterceptor" +
+                                      "LowPriorityGlobalResponseInterceptor";
+        AssertJUnit.assertEquals(executionOrderString, PriorityDataHolder.getPriorityOrder());
+    }
+
+    @BeforeMethod
+    public void reset() {
+        // Reset request interceptors
+        TestRequestInterceptor.reset();
+
+        // Reset response interceptors
+        TestResponseInterceptor.reset();
+
+        // Reset global request interceptors
+        HighPriorityGlobalRequestInterceptor.reset();
+        MediumPriorityGlobalRequestInterceptor.reset();
+        LowPriorityGlobalRequestInterceptor.reset();
+
+        // Reset global response interceptors
+        HighPriorityGlobalResponseInterceptor.reset();
+        MediumPriorityGlobalResponseInterceptor.reset();
+        LowPriorityGlobalResponseInterceptor.reset();
+
+        // Reset deprecated interceptor
+        TestInterceptorDeprecated.reset();
+    }
+}

--- a/spring/src/test/java/org/wso2/msf4j/spring/SpringInterceptorTest.java
+++ b/spring/src/test/java/org/wso2/msf4j/spring/SpringInterceptorTest.java
@@ -35,13 +35,10 @@ import org.wso2.msf4j.interceptor.PriorityDataHolder;
 import org.wso2.msf4j.interceptor.TestInterceptorDeprecated;
 import org.wso2.msf4j.interceptor.TestRequestInterceptor;
 import org.wso2.msf4j.interceptor.TestResponseInterceptor;
-import org.wso2.msf4j.service.SecondService;
 import org.wso2.msf4j.spring.service.second.TestMicroServiceWithDynamicPath;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 
 import static org.testng.Assert.assertEquals;
@@ -54,15 +51,15 @@ import static org.testng.Assert.assertEquals;
 public class SpringInterceptorTest extends InterceptorTestBase {
 
     private static final int port = Constants.PORT;
-    private List<ConfigurableApplicationContext> configurableApplicationContexts = new ArrayList<>();
+    private ConfigurableApplicationContext configurableApplicationContext;
 
     @BeforeClass
     public void setup() throws Exception {
         baseURI = URI.create(String.format(Locale.ENGLISH, "http://%s:%d", Constants.HOSTNAME, port));
-        MSF4JSpringApplication msf4JSpringApplication = new MSF4JSpringApplication(SpringHttpServerTest.class);
-        configurableApplicationContexts.add(msf4JSpringApplication.run(true, "--http.port=8090"));
-        configurableApplicationContexts.add(MSF4JSpringApplication.run(SecondService.class, "--http.port=8091"));
-        msf4JSpringApplication.addService(configurableApplicationContexts.get(1), TestMicroServiceWithDynamicPath.class,
+        configurableApplicationContext = MSF4JSpringApplication
+                .run(SpringInterceptorTest.class, "--http.port=8090");
+        MSF4JSpringApplication msf4JSpringApplication = new MSF4JSpringApplication(SpringInterceptorTest.class);
+        msf4JSpringApplication.addService(configurableApplicationContext, TestMicroServiceWithDynamicPath.class,
                 "/DynamicPath")
                 .addGlobalRequestInterceptor(new HighPriorityGlobalRequestInterceptor(),
                         new MediumPriorityGlobalRequestInterceptor(), new LowPriorityGlobalRequestInterceptor())
@@ -73,7 +70,7 @@ public class SpringInterceptorTest extends InterceptorTestBase {
 
     @AfterClass
     public void tearDown() throws Exception {
-        configurableApplicationContexts.forEach(ConfigurableApplicationContext::close);
+        configurableApplicationContext.close();
     }
 
     /**

--- a/spring/src/test/java/org/wso2/msf4j/spring/service/second/TestMicroServiceWithDynamicPath.java
+++ b/spring/src/test/java/org/wso2/msf4j/spring/service/second/TestMicroServiceWithDynamicPath.java
@@ -17,6 +17,21 @@ package org.wso2.msf4j.spring.service.second;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.wso2.msf4j.interceptor.HighPriorityClassRequestInterceptor;
+import org.wso2.msf4j.interceptor.HighPriorityClassResponseInterceptor;
+import org.wso2.msf4j.interceptor.HighPriorityMethodRequestInterceptor;
+import org.wso2.msf4j.interceptor.HighPriorityMethodResponseInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityClassRequestInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityClassResponseInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityMethodRequestInterceptor;
+import org.wso2.msf4j.interceptor.LowPriorityMethodResponseInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityClassRequestInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityClassResponseInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityMethodRequestInterceptor;
+import org.wso2.msf4j.interceptor.MediumPriorityMethodResponseInterceptor;
+import org.wso2.msf4j.interceptor.PriorityDataHolder;
+import org.wso2.msf4j.interceptor.annotation.RequestInterceptor;
+import org.wso2.msf4j.interceptor.annotation.ResponseInterceptor;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,6 +39,10 @@ import javax.ws.rs.PathParam;
 
 @SuppressWarnings("UnusedParameters")
 @Component
+@RequestInterceptor({HighPriorityClassRequestInterceptor.class, MediumPriorityClassRequestInterceptor.class,
+                     LowPriorityClassRequestInterceptor.class})
+@ResponseInterceptor({HighPriorityClassResponseInterceptor.class, MediumPriorityClassResponseInterceptor.class,
+                      LowPriorityClassResponseInterceptor.class})
 public class TestMicroServiceWithDynamicPath {
 
     @Autowired
@@ -31,7 +50,12 @@ public class TestMicroServiceWithDynamicPath {
 
     @GET
     @Path("/hello/{name}")
+    @RequestInterceptor({HighPriorityMethodRequestInterceptor.class, MediumPriorityMethodRequestInterceptor.class,
+                         LowPriorityMethodRequestInterceptor.class})
+    @ResponseInterceptor({HighPriorityMethodResponseInterceptor.class, MediumPriorityMethodResponseInterceptor.class,
+                          LowPriorityMethodResponseInterceptor.class})
     public String sayHello(@PathParam("name") String name) {
+        PriorityDataHolder.setPriorityOrder(PriorityDataHolder.getPriorityOrder() + "[SPRING HTTP METHOD]");
         return customService.sayHello(name);
     }
 }


### PR DESCRIPTION
## Purpose
Resolves #470 and #433

## Goals
Fix MSF4J Spring registering interceptors as global interceptors only

## Approach
Fixed #470 

## User stories
N/A

## Release note
* Fixed MSF4J Spring registering interceptors as global interceptors only
* Removed checkstate when registering global interceptors since checking it is not necessary.
* Fixed null pointer exception when streaming due to METHOD_PROPERTY_NAME not set
* Added test cases to test interceptor execution in MSF4J spring
* Added a sample to demonstrate MSF4J interceptor with MSF4J spring in fat-jar mode

## Documentation
N/A - This is a bug fix in MSF4J Spring interceptor execution.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   Integration tests are available in `org.wso2.msf4j.spring.SpringInterceptorTest` class

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
* [MSF4J Interceptors with MSF4J Spring - Fat Jar mode](https://github.com/vidurananayakkara/msf4j/blob/8ed31950cbfce0e9b8995f1467d9ab3bcdd136c1/samples/interceptor/spring-fatjar-interceptor-service/README.md) for using interceptors with MSF4J Spring in fat jar mode

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
* Oracle JDK 1.8
* Ubuntu 16.04
 
## Learning
N/A