### PR TITLE
Normalize @Path values by always stripping leading and trailing /

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
@@ -68,21 +68,21 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
             if (iterator.hasNext()) {
                 SwaggerService swaggerService = iterator.next();
                 swaggerService.init(this);
-                services.put("swagger", swaggerService);
+                services.put(Utils.normalizePath("swagger"), swaggerService);
             }
         }
     }
 
     public void addService(Object... service) {
         for (Object svc : service) {
-            services.put(svc.getClass().getAnnotation(Path.class).value(), svc);
+            services.put(Utils.normalizePath(svc.getClass().getAnnotation(Path.class).value()), svc);
         }
         updateMetadata();
         Arrays.stream(service).forEach(svc -> log.info("Added microservice: " + svc));
     }
 
     public void addService(String basePath, Object service) {
-        services.put(basePath, service);
+        services.put(Utils.normalizePath(basePath), service);
         metadata.addMicroserviceMetadata(service, basePath);
         log.info("Added microservice: " + service);
     }
@@ -102,7 +102,7 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
                      "' doesn't contain a root Path.");
             return;
         }
-        services.remove(path.value());
+        services.remove(Utils.normalizePath(path.value()));
         updateMetadata();
     }
 

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesRegistryImpl.java
@@ -68,7 +68,7 @@ public class MicroservicesRegistryImpl implements MicroservicesRegistry {
             if (iterator.hasNext()) {
                 SwaggerService swaggerService = iterator.next();
                 swaggerService.init(this);
-                services.put("/swagger", swaggerService);
+                services.put("swagger", swaggerService);
             }
         }
     }

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpMethodInfo.java
@@ -225,10 +225,7 @@ public class HttpMethodInfo {
                     if (Modifier.isPublic(method.getModifiers()) && Util.isHttpMethodAvailable(method)) {
                         String relativePath = "";
                         if (method.getAnnotation(Path.class) != null) {
-                            relativePath = method.getAnnotation(Path.class).value();
-                        }
-                        if (relativePath.startsWith("/")) {
-                            relativePath = relativePath.substring(1);
+                            relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
                         }
                         String absolutePath = relativePath.isEmpty() ? destination.getDestination().getPath() :
                                               String.format("%s/%s", destination.getDestination().getPath(),
@@ -240,10 +237,7 @@ public class HttpMethodInfo {
                         destination.getDestination().addSubResources(subResKey, resourceModel);
                     } else if (Modifier.isPublic(method.getModifiers()) && method.getAnnotation(Path.class) != null) {
                         // Sub resource locator method
-                        String relativePath = method.getAnnotation(Path.class).value();
-                        if (relativePath.startsWith("/")) {
-                            relativePath = relativePath.substring(1);
-                        }
+                        String relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
                         String absolutePath = relativePath.isEmpty() ? destination.getDestination().getPath() :
                                               String.format("%s/%s", destination.getDestination().getPath(),
                                                             relativePath);

--- a/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
@@ -178,7 +178,7 @@ public final class MicroserviceMetadata {
                 throw new HandlerException(Response.Status.METHOD_NOT_ALLOWED, uri);
             } else {
                 throw new HandlerException(Response.Status.NOT_FOUND,
-                        String.format("Problem accessing: %s. Reason2: Not Found", uri));
+                        String.format("Problem accessing: %s. Reason: Not Found", uri));
             }
         } catch (NoSuchElementException ex) {
             throw new HandlerException(Response.Status.UNSUPPORTED_MEDIA_TYPE,

--- a/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
@@ -73,7 +73,7 @@ public final class MicroserviceMetadata {
                     patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, false));
                 } else if (Modifier.isPublic(method.getModifiers()) && method.getAnnotation(Path.class) != null) {
                     // Sub resource locator method
-                    String relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
+                    String relativePath = method.getAnnotation(Path.class).value();
                     String absolutePath = String.format("%s/%s", basePath, relativePath);
                     patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, true));
                 } else {
@@ -102,7 +102,7 @@ public final class MicroserviceMetadata {
             if (Modifier.isPublic(method.getModifiers()) && isHttpMethodAvailable(method)) {
                 String relativePath = "";
                 if (method.getAnnotation(Path.class) != null) {
-                    relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
+                    relativePath = method.getAnnotation(Path.class).value();
                 }
                 String absolutePath = String.format("%s/%s", basePath, relativePath);
                 patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, false));

--- a/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
@@ -73,10 +73,7 @@ public final class MicroserviceMetadata {
                     patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, false));
                 } else if (Modifier.isPublic(method.getModifiers()) && method.getAnnotation(Path.class) != null) {
                     // Sub resource locator method
-                    String relativePath = method.getAnnotation(Path.class).value();
-                    if (relativePath.startsWith("/")) {
-                        relativePath = relativePath.substring(1);
-                    }
+                    String relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
                     String absolutePath = String.format("%s/%s", basePath, relativePath);
                     patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, true));
                 } else {
@@ -105,7 +102,7 @@ public final class MicroserviceMetadata {
             if (Modifier.isPublic(method.getModifiers()) && isHttpMethodAvailable(method)) {
                 String relativePath = "";
                 if (method.getAnnotation(Path.class) != null) {
-                    relativePath = method.getAnnotation(Path.class).value();
+                    relativePath = Utils.normalizePath(method.getAnnotation(Path.class).value());
                 }
                 String absolutePath = String.format("%s/%s", basePath, relativePath);
                 patternRouter.add(absolutePath, new HttpResourceModel(absolutePath, method, service, false));
@@ -145,7 +142,7 @@ public final class MicroserviceMetadata {
                                                                          List<String> acceptHeader)
             throws HandlerException {
         try {
-            String path = URI.create(uri).normalize().getPath();
+            String path = Utils.normalizePath(URI.create(uri).normalize().getPath());
 
             List<PatternPathRouter.RoutableDestination<HttpResourceModel>>
                     routableDestinations = patternRouter.getDestinations(path);
@@ -181,7 +178,7 @@ public final class MicroserviceMetadata {
                 throw new HandlerException(Response.Status.METHOD_NOT_ALLOWED, uri);
             } else {
                 throw new HandlerException(Response.Status.NOT_FOUND,
-                        String.format("Problem accessing: %s. Reason: Not Found", uri));
+                        String.format("Problem accessing: %s. Reason2: Not Found", uri));
             }
         } catch (NoSuchElementException ex) {
             throw new HandlerException(Response.Status.UNSUPPORTED_MEDIA_TYPE,

--- a/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
@@ -67,7 +67,6 @@ public final class PatternPathRouter<T> {
     public void add(final String source, final T destination) {
 
         String path = Utils.normalizePath(source);
-
         String[] parts = path.split(PATH_SLASH);
         StringBuilder sb = new StringBuilder();
         List<String> groupNames = new ArrayList<>();

--- a/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
@@ -155,7 +155,6 @@ public final class PatternPathRouter<T> {
     public List<RoutableDestination<T>> getDestinations(String path) {
 
         String cleanPath = Utils.normalizePath(path);
-
         List<RoutableDestination<T>> result = new ArrayList<>();
 
         for (ImmutablePair<Pattern, RouteDestinationWithGroups> patternRoute : patternRouteList) {

--- a/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/PatternPathRouter.java
@@ -66,12 +66,7 @@ public final class PatternPathRouter<T> {
      */
     public void add(final String source, final T destination) {
 
-        // replace multiple slashes with a single slash.
-        String path = source.replaceAll("/+", PATH_SLASH);
-
-        path = (path.endsWith(PATH_SLASH) && path.length() > 1)
-                ? path.substring(0, path.length() - 1) : path;
-
+        String path = Utils.normalizePath(source);
 
         String[] parts = path.split(PATH_SLASH);
         StringBuilder sb = new StringBuilder();
@@ -159,8 +154,7 @@ public final class PatternPathRouter<T> {
      */
     public List<RoutableDestination<T>> getDestinations(String path) {
 
-        String cleanPath = (path.endsWith(PATH_SLASH) && path.length() > 0)
-                ? path.substring(0, path.length() - 1) : path;
+        String cleanPath = Utils.normalizePath(path);
 
         List<RoutableDestination<T>> result = new ArrayList<>();
 

--- a/core/src/main/java/org/wso2/msf4j/util/Utils.java
+++ b/core/src/main/java/org/wso2/msf4j/util/Utils.java
@@ -114,4 +114,38 @@ public class Utils {
         cloneSet2.retainAll(cloneSet1);
         return cloneSet2.size();
     }
+
+    /**
+     * Get the path without leading or trailing / and with multiple / reduced to one /
+     *
+     * @param path The path
+     * @return normalized path
+     */
+    public static final String normalizePath(String path) {
+        char[] chars = path.toCharArray();
+        int p = 0;
+        boolean needSlash = false;
+
+        for (int i = 0; i < chars.length; ++i) {
+            char c = chars[i];
+            if (c != '/') {
+                needSlash = true;
+            } else if (needSlash) {
+                needSlash = false;
+            } else {
+                continue;
+            }
+
+            if (p != i) {
+                chars[p] = c;
+            }
+            ++p;
+        }
+
+        while (p > 0 && chars[p - 1] == '/') {
+            --p;
+        }
+
+        return (p == chars.length) ? path : new String(chars, 0, p);
+    }
 }

--- a/core/src/main/java/org/wso2/msf4j/util/Utils.java
+++ b/core/src/main/java/org/wso2/msf4j/util/Utils.java
@@ -142,7 +142,7 @@ public class Utils {
             ++p;
         }
 
-        while (p > 0 && chars[p - 1] == '/') {
+        if (p > 0 && !needSlash) {
             --p;
         }
 

--- a/core/src/main/java/org/wso2/msf4j/util/Utils.java
+++ b/core/src/main/java/org/wso2/msf4j/util/Utils.java
@@ -116,36 +116,12 @@ public class Utils {
     }
 
     /**
-     * Get the path without leading or trailing / and with multiple / reduced to one /
+     * Get the resource path without leading or trailing '/' and with multiple '/' reduced to one '/'
      *
-     * @param path The path
-     * @return normalized path
+     * @param resourcePath The resource path
+     * @return The normalized resource path
      */
-    public static final String normalizePath(String path) {
-        char[] chars = path.toCharArray();
-        int p = 0;
-        boolean needSlash = false;
-
-        for (int i = 0; i < chars.length; ++i) {
-            char c = chars[i];
-            if (c != '/') {
-                needSlash = true;
-            } else if (needSlash) {
-                needSlash = false;
-            } else {
-                continue;
-            }
-
-            if (p != i) {
-                chars[p] = c;
-            }
-            ++p;
-        }
-
-        if (p > 0 && !needSlash) {
-            --p;
-        }
-
-        return (p == chars.length) ? path : new String(chars, 0, p);
+    public static final String normalizePath(String resourcePath) {
+        return resourcePath.replaceAll("/+", "/").replaceAll("^/|/$", "");
     }
 }

--- a/core/src/test/java/org/wso2/msf4j/util/UtilsTest.java
+++ b/core/src/test/java/org/wso2/msf4j/util/UtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.msf4j.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests for utility class.
+ */
+public class UtilsTest {
+
+    @Test
+    public void testNormalizePath() {
+        assertEquals("hello", Utils.normalizePath("hello"));
+        assertEquals("hello", Utils.normalizePath("/hello"));
+        assertEquals("hello", Utils.normalizePath("hello/"));
+        assertEquals("hello", Utils.normalizePath("/hello/"));
+        assertEquals("hello", Utils.normalizePath("//hello"));
+        assertEquals("hello", Utils.normalizePath("///hello"));
+        assertEquals("hello", Utils.normalizePath("///hello///"));
+
+        assertEquals("hel/lo", Utils.normalizePath("hel/lo"));
+        assertEquals("hel/lo", Utils.normalizePath("hel//lo"));
+        assertEquals("hel/lo", Utils.normalizePath("hel///lo"));
+        assertEquals("hel/lo", Utils.normalizePath("//hel//lo//"));
+
+        assertEquals("h/e/ll/o", Utils.normalizePath("h/e/ll/o"));
+        assertEquals("h/e/ll/o", Utils.normalizePath("h//e//ll//o"));
+        assertEquals("h/e/ll/o", Utils.normalizePath("//h//e//ll//o//"));
+
+        assertEquals("", Utils.normalizePath(""));
+        assertEquals("", Utils.normalizePath("/"));
+        assertEquals("", Utils.normalizePath("//"));
+        assertEquals("", Utils.normalizePath("///"));
+        assertEquals("h", Utils.normalizePath("h"));
+        assertEquals("h", Utils.normalizePath("/h"));
+        assertEquals("h", Utils.normalizePath("h/"));
+    }
+}
+

--- a/core/src/test/java/org/wso2/msf4j/util/UtilsTest.java
+++ b/core/src/test/java/org/wso2/msf4j/util/UtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.msf4j.util;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -24,32 +25,45 @@ import static org.testng.AssertJUnit.assertEquals;
  */
 public class UtilsTest {
 
-    @Test
-    public void testNormalizePath() {
-        assertEquals("hello", Utils.normalizePath("hello"));
-        assertEquals("hello", Utils.normalizePath("/hello"));
-        assertEquals("hello", Utils.normalizePath("hello/"));
-        assertEquals("hello", Utils.normalizePath("/hello/"));
-        assertEquals("hello", Utils.normalizePath("//hello"));
-        assertEquals("hello", Utils.normalizePath("///hello"));
-        assertEquals("hello", Utils.normalizePath("///hello///"));
+    @DataProvider(name = "paths")
+    public String[][] paths() {
+        return new String[][] {
+            // simple paths with or without '/'
+            {"path", "path"},
+            {"/path", "path"},
+            {"path/", "path"},
+            {"/path/", "path"},
+            {"//path", "path"},
+            {"///path", "path"},
+            {"///path///", "path"},
 
-        assertEquals("hel/lo", Utils.normalizePath("hel/lo"));
-        assertEquals("hel/lo", Utils.normalizePath("hel//lo"));
-        assertEquals("hel/lo", Utils.normalizePath("hel///lo"));
-        assertEquals("hel/lo", Utils.normalizePath("//hel//lo//"));
+            // paths with multiple components
+            {"path1/path2", "path1/path2"},
+            {"path1//path2", "path1/path2"},
+            {"path1///path2", "path1/path2"},
+            {"//path1//path2//", "path1/path2"},
+            {"path1/path2/path3/path4", "path1/path2/path3/path4"},
+            {"path1//path2//path3//path4", "path1/path2/path3/path4"},
+            {"//path1//path2//path3//path4//", "path1/path2/path3/path4"},
 
-        assertEquals("h/e/ll/o", Utils.normalizePath("h/e/ll/o"));
-        assertEquals("h/e/ll/o", Utils.normalizePath("h//e//ll//o"));
-        assertEquals("h/e/ll/o", Utils.normalizePath("//h//e//ll//o//"));
+            // edge cases: empty path
+            {"", ""},
 
-        assertEquals("", Utils.normalizePath(""));
-        assertEquals("", Utils.normalizePath("/"));
-        assertEquals("", Utils.normalizePath("//"));
-        assertEquals("", Utils.normalizePath("///"));
-        assertEquals("h", Utils.normalizePath("h"));
-        assertEquals("h", Utils.normalizePath("/h"));
-        assertEquals("h", Utils.normalizePath("h/"));
+            // edge cases: paths consisting only of '/'
+            {"/", ""},
+            {"//", ""},
+            {"///", ""},
+
+            // edge cases: paths consisting only of a single character
+            {"p", "p"},
+            {"/p", "p"},
+            {"p/", "p"}
+        };
+    }
+
+    @Test(dataProvider = "paths")
+    public void testNormalizePath(String path, String expectedPath) {
+        assertEquals(expectedPath, Utils.normalizePath(path));
     }
 }
 

--- a/samples/helloworld/src/main/java/org/wso2/msf4j/example/HelloService.java
+++ b/samples/helloworld/src/main/java/org/wso2/msf4j/example/HelloService.java
@@ -23,11 +23,11 @@ import javax.ws.rs.PathParam;
 /**
  * Hello service resource class.
  */
-@Path("/hello")
+@Path("hello")
 public class HelloService {
 
     @GET
-    @Path("/{name}")
+    @Path("{name}")
     public String hello(@PathParam("name") String name) {
         System.out.println("Hello");
         return "Hello " + name;


### PR DESCRIPTION
JAX-RS spec says that leading or trailing spaces of path values should be
ignored.  This allows to use either `@Path("hello")` or `@Path("/hello")`.
Implement by trimming slashes and also replacing multiple / with a single one.

## Purpose
Resolves #479 
## Approach
Add `Utils.normalizePath` and call where necessary

## Automation tests
 - Unit tests 
   > Modified and tested with "helloworld" sample

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Modified "helloworld" to no longer use "/" in path names

