### PR TITLE
Overriding 0.0.0.0 host using 'msf4j.host' environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ public class Application {
 }
 ```
 
+You can also pass in the port(s) as an argument to the MicroservicesRunner class constructor. When passing the port(s) 
+as an argument, by default it binds to 0.0.0.0 host. Use "msf4j.host" environment variable to override the host value. 
+
 
 ### Build the Service
 Run the following Maven command. This will create the fat jar **Hello-Service-0.1-SNAPSHOT.jar** in the **target** directory.

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -52,6 +52,16 @@ import javax.ws.rs.ext.ExceptionMapper;
 public class MicroservicesRunner {
 
     private static final Logger log = LoggerFactory.getLogger(MicroservicesRunner.class);
+    
+    /**
+     * Default host used when using microservice runner starts with {@link #MicroservicesRunner(int...)}.
+     */
+    private static final String DEFAULT_HOST = "0.0.0.0";
+    
+    /**
+     * The environment variable which overrides the {@link #DEFAULT_HOST}.
+     */
+    private static final String MSF4J_HOST = "msf4j.host";
     protected List<ServerConnector> serverConnectors = new ArrayList<>();
     private long startTime = System.currentTimeMillis();
     private boolean isStarted;
@@ -199,7 +209,8 @@ public class MicroservicesRunner {
         transportsConfiguration.setTransportProperties(transportProperties);
         Set<ListenerConfiguration> listenerConfigurations = new HashSet<>();
         for (int port : ports) {
-            ListenerConfiguration listenerConfiguration = new ListenerConfiguration("netty-" + port, "0.0.0.0", port);
+            ListenerConfiguration listenerConfiguration = new ListenerConfiguration("netty-" + port,
+                    System.getProperty(MSF4J_HOST, DEFAULT_HOST), port);
             DataHolder.getInstance().getMicroservicesRegistries().put(listenerConfiguration.getId(), msRegistry);
             listenerConfigurations.add(listenerConfiguration);
         }

--- a/core/src/test/java/org/wso2/msf4j/HostBindingTest.java
+++ b/core/src/test/java/org/wso2/msf4j/HostBindingTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.msf4j;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.msf4j.service.TestMicroservice;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+/**
+ * Testing the "msf4j.host" environment variable.
+ */
+public class HostBindingTest {
+    private final TestMicroservice testMicroservice = new TestMicroservice();
+    
+    /**
+     * Testing happy path.
+     */
+    @Test
+    public void testHostForMicroserviceRunner() {
+        MicroservicesRunner microservicesRunner = new MicroservicesRunner(3333);
+        microservicesRunner.deploy(testMicroservice);
+        microservicesRunner.start();
+        Assert.assertTrue(this.isHostPortAvailable("127.0.0.1", 3333),
+                                                                "Unable to connect to service started on 127.0.0.1");
+        Assert.assertTrue(this.isHostPortAvailable("localhost", 3333),
+                                                                "Unable to connect to service started on localhost");
+        microservicesRunner.stop();
+    }
+    
+    /**
+     * Hosting a test microservice on 127.0.0.1 and check if it can be accessed with 127.0.0.1 and that it cannot be
+     * accessed through any other network ip.
+     */
+    @Test
+    public void testDifferentHostForMicroserviceRunner() throws SocketException {
+        System.setProperty("msf4j.host", "127.0.0.1");
+        MicroservicesRunner microservicesRunner = new MicroservicesRunner(4444);
+        microservicesRunner.deploy(testMicroservice);
+        microservicesRunner.start();
+        Assert.assertTrue(this.isHostPortAvailable("127.0.0.1", 4444),
+                                                                "Unable to connect to service started on 127.0.0.1");
+        Assert.assertTrue(this.isHostPortAvailable("localhost", 4444),
+                                                                "Unable to connect to service started on localhost");
+        Enumeration e = NetworkInterface.getNetworkInterfaces();
+        while (e.hasMoreElements()) {
+            NetworkInterface n = (NetworkInterface) e.nextElement();
+            Enumeration ee = n.getInetAddresses();
+            while (ee.hasMoreElements()) {
+                InetAddress i = (InetAddress) ee.nextElement();
+                String networkHost = i.getHostAddress();
+                if (!networkHost.equals("127.0.0.1") && !networkHost.equals("localhost")) {
+                    Assert.assertFalse(this.isHostPortAvailable(networkHost, 4444),
+                                                                    "Should not be able to connect on " + networkHost);
+                }
+            }
+        }
+        System.clearProperty("msf4j.host");
+        microservicesRunner.stop();
+    }
+    
+    /**
+     * Check if a port is open with a given host. An SO timeout of 3000 milliseconds is used.
+     * @param host The host to be checked.
+     * @param port The port to be checked.
+     * @return True if available, else false.
+     */
+    private boolean isHostPortAvailable(String host, int port) {
+        try {
+            boolean isConnected;
+            Socket client = new Socket();
+            client.connect(new InetSocketAddress(host, port), 3000);
+            isConnected = client.isConnected();
+            client.close();
+            return isConnected;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+}

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -90,4 +90,10 @@ limitations under the License.
         </classes>
     </test>
 
+    <test name="host-binding-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.msf4j.HostBindingTest"/>
+        </classes>
+    </test>
+
 </suite>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/msf4j/issues/483

## Goals
Providing the hostname as "msf4j.host" environment variable will override the default 0.0.0.0 host bind.

## Approach
Using an environment variable to override the host value.

## User stories
The user wants to bind service(s) to an IP instead of 0.0.0.0.

## Documentation
This PR contains the documentation.

## Certification
N/A - No learning curve.

## Automation tests
 - Unit tests 
   > Code coverage information - No
 - Integration tests
   > Created test case to check the ports are open with the host.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? no

## Test environment
java version "1.8.0_45", MacOs, Maven 3.5.0