### PR TITLE
Fix the issue when building fatjar with transport version upgrade

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,10 @@
                     <groupId>org.wso2.carbon.messaging</groupId>
                     <artifactId>org.wso2.carbon.messaging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.wso2.orbit.org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
@@ -59,7 +59,6 @@ import javax.ws.rs.ext.ExceptionMapper;
 public class MSF4JHttpConnectorListener implements HttpConnectorListener {
 
     private static final Logger log = LoggerFactory.getLogger(MSF4JHttpConnectorListener.class);
-    private static final String MSF4J_MSG_PROC_ID = "MSF4J-CM-PROCESSOR";
     private ExecutorService executorService;
 
     public MSF4JHttpConnectorListener() {


### PR DESCRIPTION
## Purpose
Fix the issue when building fatjar with transport version upgrade. Below version popup when building fat microservice jar

````
[INFO] Including commons-io.wso2:commons-io:jar:2.4.0.wso2v1 in the shaded jar.
[WARNING] snakeyaml-1.16.0.wso2v1.jar, snakeyaml-1.17.jar define 201 overlapping classes:
[WARNING]   - org.yaml.snakeyaml.emitter.Emitter$ExpectBlockMappingValue
[WARNING]   - org.yaml.snakeyaml.parser.ParserImpl$ParseBlockNode
[WARNING]   - org.yaml.snakeyaml.emitter.Emitter$ExpectBlockMappingSimpleValue
[WARNING]   - org.yaml.snakeyaml.emitter.Emitter$ExpectDocumentEnd
[WARNING]   - org.yaml.snakeyaml.Yaml$3
[WARNING]   - org.yaml.snakeyaml.emitter.Emitter$ExpectBlockSequenceItem
[WARNING]   - org.yaml.snakeyaml.parser.ParserImpl$ParseBlockSequenceEntry
[WARNING]   - org.yaml.snakeyaml.tokens.Token$ID
[WARNING]   - org.yaml.snakeyaml.reader.StreamReader
[WARNING]   - org.yaml.snakeyaml.representer.SafeRepresenter$RepresentList
[WARNING]   - 191 more...
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://docs.codehaus.org/display/MAVENUSER/Shade+Plugin
````

## Goals
Fixed the issue and remove unused constant defined.