### PR TITLE
Fix the issue in reading transport configs from deployment yaml

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/MicroservicesServer.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesServer.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.msf4j;
+
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+
+import java.util.Map;
+
+/**
+ * Interface to handle server details of Microservices server. transport details etc.
+ * <p>
+ * This interface handles server details of microservices server in OSGi environment.
+ *
+ * @since 4.5.0
+ */
+public interface MicroservicesServer {
+
+    /**
+     * Provide Listener Configuration details with server connector id used in microservices server.
+     *
+     * @return ListenerConfigurationMap
+     */
+    public Map<String, ListenerConfiguration> getListenerConfigurations();
+}

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesServerImpl.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesServerImpl.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2017 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.msf4j;
+
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+
+import java.util.Map;
+
+/**
+ * Handles details relates microservices server. transport details etc.
+ */
+public class MicroservicesServerImpl implements MicroservicesServer {
+
+    private final Map<String, ListenerConfiguration> listenerConfigurationMap;
+
+    public MicroservicesServerImpl(Map<String, ListenerConfiguration> configurationMap) {
+        listenerConfigurationMap = configurationMap;
+    }
+
+
+    @Override
+    public Map<String, ListenerConfiguration> getListenerConfigurations() {
+        return listenerConfigurationMap;
+    }
+}

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
@@ -22,6 +22,8 @@ public class MSF4JConstants {
 
     public static final String SESSION_ID = "JSESSIONID=";
     public static final String CHANNEL_ID = "LISTENER_INTERFACE_ID";
+    public static final String CONTEXT_PATH = "contextPath";
+    public static final String WSO2_TRANSPORT_HTTP_CONFIG_NAMESPACE = "wso2.transport.http";
 
     // Property constants
     public static final String METHOD_PROPERTY_NAME = "method";

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -735,8 +735,8 @@
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
         <carbon.utils.version>2.0.2</carbon.utils.version>
         <carbon.utils.package.import.version.range>[2.0.0, 3.0.0)</carbon.utils.package.import.version.range>
-        <carbon.config.version>2.1.2</carbon.config.version>
-        <carbon.config.package.import.version.range>[2.0.0, 3.0.0)</carbon.config.package.import.version.range>
+        <carbon.config.version>2.1.5</carbon.config.version>
+        <carbon.config.package.import.version.range>[2.1.5, 3.0.0)</carbon.config.package.import.version.range>
         <carbon.secvault.version>5.0.8</carbon.secvault.version>
         <carbon.secvault.version.range>[5.0.0, 6.0.0)</carbon.secvault.version.range>
         <carbon.deployment.version>5.1.5</carbon.deployment.version>

--- a/tests/test-distribution/carbon-home/conf/deployment.yaml
+++ b/tests/test-distribution/carbon-home/conf/deployment.yaml
@@ -34,3 +34,20 @@ wso2.securevault:
     type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
     parameters:
       masterKeyReaderFile: ${sys:carbon.home}/conf/${sys:wso2.runtime}/master-keys.yaml
+
+wso2.transport.http:
+  transportProperties:
+   - name: "latency.metrics.enabled"
+     value: true
+   - name: "server.bootstrap.socket.timeout"
+     value: 60
+   - name: "client.bootstrap.socket.timeout"
+     value: 60
+
+  listenerConfigurations:
+   - id: "default"
+     host: "0.0.0.0"
+     port: 8080
+
+  senderConfigurations:
+   - id: "http-sender"


### PR DESCRIPTION
## Purpose
This PR is to fix the issue in reading the transport configs from deployment yaml. Without this fix server always start with default configuration. There is no way of changing configuration.

## Goals
Enable user to change transport configuration from deployment yaml

## Approach
Update configuration provider with new api to read configuration with different namespace.

## User stories
If your needs to change configuration, they need to add below configuration to deployment yaml file.

````yaml
wso2.transport.http:
  transportProperties:
   - name: "latency.metrics.enabled"
     value: true
   - name: "server.bootstrap.socket.timeout"
     value: 60
   - name: "client.bootstrap.socket.timeout"
     value: 60

  listenerConfigurations:
   - id: "default"
     host: "0.0.0.0"
     port: 8080

  senderConfigurations:
   - id: "http-sender"
````