### PR TITLE
Add MSF4JWSConnectorListener to support web sockets and transport version upgrade

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -22,6 +22,7 @@ import org.wso2.msf4j.interceptor.ResponseInterceptor;
 import org.wso2.msf4j.internal.DataHolder;
 import org.wso2.msf4j.internal.HttpConnectorPortBindingListener;
 import org.wso2.msf4j.internal.MSF4JHttpConnectorListener;
+import org.wso2.msf4j.internal.MSF4JWSConnectorListener;
 import org.wso2.msf4j.internal.MicroservicesRegistryImpl;
 import org.wso2.msf4j.internal.websocket.EndpointsRegistryImpl;
 import org.wso2.msf4j.util.RuntimeAnnotations;
@@ -247,9 +248,11 @@ public class MicroservicesRunner {
         msRegistry.getSessionManager().init();
         handleServiceLifecycleMethods();
         MSF4JHttpConnectorListener msf4JHttpConnectorListener = new MSF4JHttpConnectorListener();
+        MSF4JWSConnectorListener msf4JWSConnectorListener = new MSF4JWSConnectorListener();
         serverConnectors.forEach(serverConnector -> {
             ServerConnectorFuture serverConnectorFuture = serverConnector.start();
             serverConnectorFuture.setHttpConnectorListener(msf4JHttpConnectorListener);
+            serverConnectorFuture.setWSConnectorListener(msf4JWSConnectorListener);
             serverConnectorFuture.setPortBindingEventListener(new HttpConnectorPortBindingListener());
             isStarted = true;
             log.info("Microservices server started in " + (System.currentTimeMillis() - startTime) + "ms");

--- a/core/src/main/java/org/wso2/msf4j/Request.java
+++ b/core/src/main/java/org/wso2/msf4j/Request.java
@@ -19,8 +19,12 @@ package org.wso2.msf4j;
 import io.netty.buffer.ByteBuf;
 import org.wso2.msf4j.internal.MSF4JConstants;
 import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.contract.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.HttpResponseStatusFuture;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -239,7 +243,28 @@ public class Request {
      *
      * @return HTTPCarbonMessage instance of the Request
      */
-    public HTTPCarbonMessage getHttpCarbonMessage() {
+    HTTPCarbonMessage getHttpCarbonMessage() {
         return httpCarbonMessage;
+    }
+
+    /**
+     * Method use to send the response to the caller.
+     *
+     * @param carbonMessage Response message
+     * @return true if no errors found, else otherwise
+     * @throws ServerConnectorException server connector exception.
+     */
+    public boolean respond(HTTPCarbonMessage carbonMessage) throws ServerConnectorException {
+        HttpResponseStatusFuture statusFuture = httpCarbonMessage.respond(carbonMessage);
+        return statusFuture.getStatus().getCause() == null;
+    }
+
+    /**
+     * Returns InputStream of the ByteBuffers in message content.
+     *
+     * @return InputStream of the ByteBuffers
+     */
+    public InputStream getMessageContentStream() {
+        return new HttpMessageDataStreamer(httpCarbonMessage).getInputStream();
     }
 }

--- a/core/src/main/java/org/wso2/msf4j/formparam/RequestContext.java
+++ b/core/src/main/java/org/wso2/msf4j/formparam/RequestContext.java
@@ -17,7 +17,6 @@
 package org.wso2.msf4j.formparam;
 
 import org.wso2.msf4j.Request;
-import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -57,7 +56,7 @@ public class RequestContext {
      * @return InputStream request's inputstream
      */
     public InputStream getInputStream() {
-        return new HttpMessageDataStreamer(request.getHttpCarbonMessage()).getInputStream();
+        return request.getMessageContentStream();
     }
 
 }

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JWSConnectorListener.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JWSConnectorListener.java
@@ -1,0 +1,343 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.msf4j.internal;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.msf4j.internal.router.PatternPathRouter;
+import org.wso2.msf4j.internal.websocket.CloseCodeImpl;
+import org.wso2.msf4j.internal.websocket.EndpointDispatcher;
+import org.wso2.msf4j.internal.websocket.EndpointsRegistryImpl;
+import org.wso2.msf4j.internal.websocket.WebSocketPongMessage;
+import org.wso2.msf4j.websocket.exception.WebSocketEndpointMethodReturnTypeException;
+import org.wso2.transport.http.netty.contract.websocket.HandshakeFuture;
+import org.wso2.transport.http.netty.contract.websocket.HandshakeListener;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketCloseMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketConnectorListener;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketControlMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.websocket.CloseReason;
+import javax.websocket.PongMessage;
+import javax.websocket.Session;
+import javax.websocket.server.PathParam;
+
+/**
+ * WebSocketConnectorListener implementation for MSF4J.
+ *
+ * This will process all the websocket messages which are coming to MSF4J.
+ */
+@Component(
+        name = "org.wso2.msf4j.internal.MSF4JWSConnectorListener",
+        immediate = true,
+        service = WebSocketConnectorListener.class
+)
+public class MSF4JWSConnectorListener implements WebSocketConnectorListener {
+
+    private static final Logger log = LoggerFactory.getLogger(MSF4JWSConnectorListener.class);
+
+    @Override
+    public void onMessage(WebSocketInitMessage webSocketInitMessage) {
+        HandshakeFuture handshakeFuture = webSocketInitMessage.handshake();
+        handshakeFuture.setHandshakeListener(new HandshakeListener() {
+            @Override
+            public void onSuccess(Session session) {
+                handleWebSocketHandshake(webSocketInitMessage, session);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                log.error("Unexpected error occur while handshake.", throwable);
+            }
+        });
+    }
+
+    @Override
+    public void onMessage(WebSocketTextMessage webSocketTextMessage) {
+        EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
+        String uri = webSocketTextMessage.getTarget();
+        PatternPathRouter.RoutableDestination<Object> routableEndpoint = endpointsRegistry.getRoutableEndpoint(uri);
+        handleTextWebSocketMessage(webSocketTextMessage, routableEndpoint, webSocketTextMessage.getChannelSession());
+    }
+
+    @Override
+    public void onMessage(WebSocketBinaryMessage webSocketBinaryMessage) {
+        EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
+        String uri = webSocketBinaryMessage.getTarget();
+        PatternPathRouter.RoutableDestination<Object> routableEndpoint = endpointsRegistry.getRoutableEndpoint(uri);
+        handleBinaryWebSocketMessage(webSocketBinaryMessage, routableEndpoint,
+                webSocketBinaryMessage.getChannelSession());
+    }
+
+    @Override
+    public void onMessage(WebSocketControlMessage webSocketControlMessage) {
+        EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
+        String uri = webSocketControlMessage.getTarget();
+        PatternPathRouter.RoutableDestination<Object> routableEndpoint = endpointsRegistry.getRoutableEndpoint(uri);
+        handleControlCarbonMessage(webSocketControlMessage, routableEndpoint,
+                webSocketControlMessage.getChannelSession());
+    }
+
+    @Override
+    public void onMessage(WebSocketCloseMessage webSocketCloseMessage) {
+        EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
+        String uri = webSocketCloseMessage.getTarget();
+        PatternPathRouter.RoutableDestination<Object> routableEndpoint = endpointsRegistry.getRoutableEndpoint(uri);
+        handleCloseWebSocketMessage(webSocketCloseMessage, routableEndpoint, webSocketCloseMessage.getChannelSession());
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log.error("Unexpected error occur.", throwable);
+    }
+
+    @Override
+    public void onIdleTimeout(WebSocketControlMessage webSocketControlMessage) {
+
+    }
+
+    private boolean handleWebSocketHandshake(WebSocketInitMessage carbonMessage, Session session) {
+        EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
+        String requestUri = carbonMessage.getTarget();
+        PatternPathRouter.RoutableDestination<Object> routableEndpoint =
+                endpointsRegistry.getRoutableEndpoint(requestUri);
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnOpenMethod(routableEndpoint.getDestination());
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        try {
+            List<Object> parameterList = new LinkedList<>();
+            methodOptional.ifPresent(method -> {
+                Arrays.stream(method.getParameters()).forEach(parameter -> {
+                    if (parameter.getType() == Session.class) {
+                        parameterList.add(session);
+                    } else if (parameter.getType() == String.class) {
+                        PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                        if (pathParam != null) {
+                            parameterList.add(paramValues.get(pathParam.value()));
+                        }
+                    } else {
+                        parameterList.add(null);
+                    }
+                });
+                executeMethod(method, routableEndpoint.getDestination(), parameterList, session);
+            });
+            return true;
+        } catch (Throwable throwable) {
+            handleError(throwable, routableEndpoint, session);
+            return false;
+        }
+    }
+
+    private void handleTextWebSocketMessage(WebSocketTextMessage textCarbonMessage,
+                                            PatternPathRouter.RoutableDestination<Object> routableEndpoint,
+                                            Session session) {
+        Object endpoint = routableEndpoint.getDestination();
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnStringMessageMethod(endpoint);
+        try {
+            methodOptional.ifPresent(
+                    method -> {
+                        List<Object> parameterList = new LinkedList<>();
+                        Arrays.stream(method.getParameters()).forEach(
+                                parameter -> {
+                                    if (parameter.getType() == String.class) {
+                                        PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                                        if (pathParam == null) {
+                                            parameterList.add(textCarbonMessage.getText());
+                                        } else {
+                                            parameterList.add(paramValues.get(pathParam.value()));
+                                        }
+                                    } else if (parameter.getType() == Session.class) {
+                                        parameterList.add(session);
+                                    } else {
+                                        parameterList.add(null);
+                                    }
+                                }
+                        );
+                        executeMethod(method, endpoint, parameterList, session);
+                    }
+            );
+        } catch (Throwable throwable) {
+            handleError(throwable, routableEndpoint, session);
+        }
+    }
+
+    private void handleBinaryWebSocketMessage(WebSocketBinaryMessage binaryCarbonMessage,
+                                              PatternPathRouter.RoutableDestination<Object> routableEndpoint,
+                                              Session session) {
+        Object webSocketEndpoint = routableEndpoint.getDestination();
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnBinaryMessageMethod(webSocketEndpoint);
+        try {
+            methodOptional.ifPresent(method -> {
+                List<Object> parameterList = new LinkedList<>();
+                Arrays.stream(method.getParameters()).forEach(parameter -> {
+                    if (parameter.getType() == ByteBuffer.class) {
+                        parameterList.add(binaryCarbonMessage.getByteBuffer());
+                    } else if (parameter.getType() == byte[].class) {
+                        ByteBuffer buffer = binaryCarbonMessage.getByteBuffer();
+                        byte[] bytes = new byte[buffer.capacity()];
+                        for (int i = 0; i < buffer.capacity(); i++) {
+                            bytes[i] = buffer.get();
+                        }
+                        parameterList.add(bytes);
+                    } else if (parameter.getType() == boolean.class) {
+                        parameterList.add(binaryCarbonMessage.isFinalFragment());
+                    } else if (parameter.getType() == Session.class) {
+                        parameterList.add(session);
+                    } else if (parameter.getType() == String.class) {
+                        PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                        if (pathParam != null) {
+                            parameterList.add(paramValues.get(pathParam.value()));
+                        }
+                    } else {
+                        parameterList.add(null);
+                    }
+                });
+                executeMethod(method, webSocketEndpoint, parameterList, session);
+            });
+        } catch (Throwable throwable) {
+            handleError(throwable, routableEndpoint, session);
+        }
+    }
+
+    private void handleCloseWebSocketMessage(WebSocketCloseMessage closeCarbonMessage,
+                                             PatternPathRouter.RoutableDestination<Object> routableEndpoint,
+                                             Session session) {
+        Object webSocketEndpoint = routableEndpoint.getDestination();
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnCloseMethod(webSocketEndpoint);
+        try {
+            methodOptional.ifPresent(method -> {
+                List<Object> parameterList = new LinkedList<>();
+                Arrays.stream(method.getParameters()).forEach(parameter -> {
+                    if (parameter.getType() == CloseReason.class) {
+                        CloseReason.CloseCode closeCode = new CloseCodeImpl(closeCarbonMessage.getCloseCode());
+                        CloseReason closeReason = new CloseReason(closeCode, closeCarbonMessage.getCloseReason());
+                        parameterList.add(closeReason);
+                    } else if (parameter.getType() == Session.class) {
+                        parameterList.add(session);
+                    } else if (parameter.getType() == String.class) {
+                        PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                        if (pathParam != null) {
+                            parameterList.add(paramValues.get(pathParam.value()));
+                        }
+                    } else {
+                        parameterList.add(null);
+                    }
+                });
+                executeMethod(method, webSocketEndpoint, parameterList, session);
+            });
+        } catch (Throwable throwable) {
+            handleError(throwable, routableEndpoint, session);
+        }
+    }
+
+    private void handleControlCarbonMessage(WebSocketControlMessage controlCarbonMessage, PatternPathRouter.
+            RoutableDestination<Object> routableEndpoint, Session session) {
+        Object webSocketEndpoint = routableEndpoint.getDestination();
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnPongMessageMethod(webSocketEndpoint);
+        try {
+            methodOptional.ifPresent(method -> {
+                List<Object> parameterList = new LinkedList<>();
+                Arrays.stream(method.getParameters()).forEach(parameter -> {
+                    if (parameter.getType() == PongMessage.class) {
+                        parameterList.add(new WebSocketPongMessage(controlCarbonMessage.getPayload()));
+                    } else if (parameter.getType() == Session.class) {
+                        parameterList.add(session);
+                    } else if (parameter.getType() == String.class) {
+                        PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                        if (pathParam != null) {
+                            parameterList.add(paramValues.get(pathParam.value()));
+                        }
+                    } else {
+                        parameterList.add(null);
+                    }
+                });
+                executeMethod(method, webSocketEndpoint, parameterList, session);
+            });
+        } catch (Throwable throwable) {
+            handleError(throwable, routableEndpoint, session);
+        }
+    }
+
+    private void handleError(Throwable throwable, PatternPathRouter.RoutableDestination<Object> routableEndpoint,
+                             Session session) {
+        Object webSocketEndpoint = routableEndpoint.getDestination();
+        Map<String, String> paramValues = routableEndpoint.getGroupNameValues();
+        Optional<Method> methodOptional = new EndpointDispatcher().getOnErrorMethod(webSocketEndpoint);
+        methodOptional.ifPresent(method -> {
+            List<Object> parameterList = new LinkedList<>();
+            Arrays.stream(method.getParameters()).forEach(parameter -> {
+                if (parameter.getType() == Throwable.class) {
+                    parameterList.add(throwable);
+                } else if (parameter.getType() == Session.class) {
+                    parameterList.add(session);
+                } else if (parameter.getType() == String.class) {
+                    PathParam pathParam = parameter.getAnnotation(PathParam.class);
+                    if (pathParam != null) {
+                        parameterList.add(paramValues.get(pathParam.value()));
+                    }
+                } else {
+                    parameterList.add(null);
+                }
+            });
+            executeMethod(method, webSocketEndpoint, parameterList, session);
+        });
+    }
+
+    private void executeMethod(Method method, Object webSocketEndpoint, List<Object> parameterList, Session session) {
+        try {
+            if (method.getReturnType() == String.class) {
+                String returnStr = (String) method.invoke(webSocketEndpoint, parameterList.toArray());
+                session.getBasicRemote().sendText(returnStr);
+            } else if (method.getReturnType() == ByteBuffer.class) {
+                ByteBuffer buffer = (ByteBuffer) method.invoke(webSocketEndpoint, parameterList.toArray());
+                session.getBasicRemote().sendBinary(buffer);
+            } else if (method.getReturnType() == byte[].class) {
+                byte[] bytes = (byte[]) method.invoke(webSocketEndpoint, parameterList.toArray());
+                session.getBasicRemote().sendBinary(ByteBuffer.wrap(bytes));
+            } else if (method.getReturnType() == void.class) {
+                method.invoke(webSocketEndpoint, parameterList.toArray());
+            } else if (method.getReturnType() == PongMessage.class) {
+                PongMessage pongMessage = (PongMessage) method.invoke(webSocketEndpoint, parameterList.toArray());
+                session.getBasicRemote().sendPong(pongMessage.getApplicationData());
+            } else {
+                throw new WebSocketEndpointMethodReturnTypeException("Unknown return type.");
+            }
+        } catch (IllegalAccessException e) {
+            log.error("Illegal access exception occurred: " + e.toString());
+        } catch (InvocationTargetException e) {
+            log.error("Method invocation failed: " + e.toString());
+        } catch (IOException e) {
+            log.error("IOException occurred: " + e.toString());
+        } catch (WebSocketEndpointMethodReturnTypeException e) {
+            log.error("WebSocket method return type exception occurred: " + e.toString());
+        }
+    }
+}

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
@@ -77,6 +77,7 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
     private boolean isAllRequiredCapabilitiesAvailable;
     private List<ServerConnector> serverConnectors = new ArrayList<>();
     private MSF4JHttpConnectorListener msf4JHttpConnectorListener;
+    private MSF4JWSConnectorListener msf4JWSConnectorListener;
     private Map<String, ListenerConfiguration> listenerConfigurationMap = new HashMap<>();
 
     @Activate
@@ -379,6 +380,7 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
         }
 
         msf4JHttpConnectorListener = new MSF4JHttpConnectorListener();
+        msf4JWSConnectorListener = new MSF4JWSConnectorListener();
         DataHolder.getInstance().getBundleContext()
                 .registerService(HttpConnectorListener.class, msf4JHttpConnectorListener, null);
         DataHolder.getInstance().getBundleContext().registerService(MicroservicesServerSC.class, this, null);
@@ -388,6 +390,7 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
         serverConnectors.forEach(serverConnector -> {
             final ServerConnectorFuture serverConnectorFuture = serverConnector.start();
             serverConnectorFuture.setHttpConnectorListener(msf4JHttpConnectorListener);
+            serverConnectorFuture.setWSConnectorListener(msf4JWSConnectorListener);
         });
     }
 

--- a/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModelProcessor.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/HttpResourceModelProcessor.java
@@ -30,7 +30,6 @@ import org.wso2.msf4j.formparam.exception.FormUploadException;
 import org.wso2.msf4j.formparam.util.StreamUtil;
 import org.wso2.msf4j.internal.beanconversion.BeanConverter;
 import org.wso2.msf4j.util.QueryStringDecoderUtil;
-import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -157,8 +156,7 @@ public class HttpResourceModelProcessor {
 
     private void createObject(Request request, Object[] args, int idx, HttpResourceModel.ParameterInfo<?> paramInfo)
             throws IOException {
-        HttpMessageDataStreamer dataStreamer = new HttpMessageDataStreamer(request.getHttpCarbonMessage());
-        try (InputStream inputStream = dataStreamer.getInputStream()) {
+        try (InputStream inputStream = request.getMessageContentStream()) {
             Type paramType = paramInfo.getParameterType();
             args[idx] =
                     BeanConverter.getConverter((request.getContentType() != null) ? request.getContentType() :
@@ -249,8 +247,7 @@ public class HttpResourceModelProcessor {
                 }
             }
         } else if (MediaType.APPLICATION_FORM_URLENCODED.equals(request.getContentType())) {
-            HttpMessageDataStreamer dataStreamer = new HttpMessageDataStreamer(request.getHttpCarbonMessage());
-            try (InputStream inputStream = dataStreamer.getInputStream()) {
+            try (InputStream inputStream = request.getMessageContentStream()) {
                 String bodyStr = BeanConverter
                         .getConverter((request.getContentType() != null) ? request.getContentType() : MediaType
                                 .WILDCARD).convertToObject(inputStream, paramInfo.getParameterType()).toString();
@@ -304,8 +301,7 @@ public class HttpResourceModelProcessor {
                     }
                 }
             } else if (MediaType.APPLICATION_FORM_URLENCODED.equals(request.getContentType())) {
-                HttpMessageDataStreamer dataStreamer = new HttpMessageDataStreamer(request.getHttpCarbonMessage());
-                try (InputStream inputStream = dataStreamer.getInputStream()) {
+                try (InputStream inputStream = request.getMessageContentStream()) {
                     String bodyStr = BeanConverter.getConverter(
                             (request.getContentType() != null) ? request.getContentType() : MediaType.WILDCARD)
                             .convertToObject(inputStream, paramInfo.getParameterType()).toString();
@@ -348,8 +344,7 @@ public class HttpResourceModelProcessor {
             if (MediaType.MULTIPART_FORM_DATA.equals(request.getContentType())) {
                 listMultivaluedMap = extractRequestFormParams(request, paramInfo, false);
             } else if (MediaType.APPLICATION_FORM_URLENCODED.equals(request.getContentType())) {
-                HttpMessageDataStreamer dataStreamer = new HttpMessageDataStreamer(request.getHttpCarbonMessage());
-                try (InputStream inputStream = dataStreamer.getInputStream()) {
+                try (InputStream inputStream = request.getMessageContentStream()) {
                     String bodyStr = BeanConverter.getConverter(
                             (request.getContentType() != null) ? request.getContentType() : MediaType.WILDCARD)
                             .convertToObject(inputStream, paramInfo.getParameterType()).toString();

--- a/core/src/main/java/org/wso2/msf4j/io/MSF4JRequestInputStream.java
+++ b/core/src/main/java/org/wso2/msf4j/io/MSF4JRequestInputStream.java
@@ -15,12 +15,11 @@
 */
 package org.wso2.msf4j.io;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http.HttpContent;
 import org.wso2.msf4j.Request;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 /**
  * Wrapper {@link InputStream} for {@link Request}.
@@ -28,30 +27,25 @@ import java.io.InputStream;
 @Deprecated
 public class MSF4JRequestInputStream extends InputStream {
     private Request request;
-    private ByteBuf byteBuf = null;
-    private HttpContent httpContent = null;
+    private ByteBuffer buffer;
 
     public MSF4JRequestInputStream(Request request) {
         this.request = request;
-        httpContent = request.getHttpCarbonMessage().getHttpContent();
-        byteBuf = httpContent.content();
+        buffer = request.getMessageBody().nioBuffer();
     }
 
     @Override
     public int read() throws IOException {
-        if (request.isEmpty() && request.getHttpCarbonMessage().isEmpty() && !byteBuf.isReadable()) {
-            httpContent.release();
+        if (request.isEomAdded() && request.isEmpty() && !buffer.hasRemaining()) {
             return -1;
-        } else if (!byteBuf.isReadable()) {
-            httpContent.release();
-            httpContent = request.getHttpCarbonMessage().getHttpContent();
-            byteBuf = httpContent.content();
+        } else if (!buffer.hasRemaining()) {
+            buffer = request.getMessageBody().nioBuffer();
         }
-        return byteBuf.readByte();
+        return buffer.get() & 0xFF;
     }
 
     @Override
     public int available() throws IOException {
-        return byteBuf.writerIndex() - byteBuf.readerIndex();
+        return buffer.remaining();
     }
 }

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -74,8 +74,7 @@ limitations under the License.
         <classes>
             <class name="org.wso2.msf4j.websocket.ValidatorTest"/>
             <class name="org.wso2.msf4j.websocket.EndpointRegistryTest"/>
-            <!-- temporary disabled. we need to fix the testcase. tracking issue #496-->
-<!--            <class name="org.wso2.msf4j.websocket.DeploymentTest"/>-->
+            <class name="org.wso2.msf4j.websocket.DeploymentTest"/>
         </classes>
     </test>
 

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -745,7 +745,7 @@
         <carbon.messaging.version.range>[3,4)</carbon.messaging.version.range>
         <carbon.jndi.version>1.0.4</carbon.jndi.version>
         <carbon.datasources.version>1.1.3</carbon.datasources.version>
-        <org.wso2.transport.http.version>6.0.51</org.wso2.transport.http.version>
+        <org.wso2.transport.http.version>6.0.56</org.wso2.transport.http.version>
         <org.wso2.transport.http.version.range>[6.0,7)</org.wso2.transport.http.version.range>
         <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <org.apache.httpcomponents.httpclient.version>4.5.2</org.apache.httpcomponents.httpclient.version>


### PR DESCRIPTION
## Purpose
This is to add MSF4JWSConnectorListener to support web sockets
Transport version upgrade to avoid warning in server startup.
Avoid exposing httpCarbonMessage from Request object

## Goals
This PR to other branch to complete the transport upgrade.

## Approach
Create new class MSF4JWSConnectorListener implementing WebSocketConnectorListener

## User stories
Web socket support.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Already available

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.111
 
## Learning
Transport new implemetation.