### PR TITLE
Change HttpWsConnectorFactory initialization to read from transport configuration

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -212,7 +212,7 @@ public class MicroservicesRunner {
         String transportYaml = System.getProperty(TRANSPORTS_NETTY_CONF);
         if (transportYaml == null || transportYaml.isEmpty()) {
             ServerBootstrapConfiguration bootstrapConfiguration = ServerBootstrapConfiguration.getInstance();
-            ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+            ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
             ServerConnector serverConnector =
                     connectorFactory.createServerConnector(bootstrapConfiguration, listenerConfiguration);
             DataHolder.getInstance().getMicroservicesRegistries()

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -26,6 +26,7 @@ import org.wso2.msf4j.internal.MSF4JWSConnectorListener;
 import org.wso2.msf4j.internal.MicroservicesRegistryImpl;
 import org.wso2.msf4j.internal.websocket.EndpointsRegistryImpl;
 import org.wso2.msf4j.util.RuntimeAnnotations;
+import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.config.ConfigurationBuilder;
 import org.wso2.transport.http.netty.config.ListenerConfiguration;
@@ -58,8 +59,11 @@ public class MicroservicesRunner {
     /**
      * The environment variable which overrides the {@link #DEFAULT_HOST}.
      */
-    private static final String TRANSPORTS_NETTY_CONF = "transports.netty.conf";
     private static final String MSF4J_HOST = "msf4j.host";
+    /**
+     * The environment variable which have netty transport configuration file path.
+     */
+    private static final String TRANSPORTS_NETTY_CONF = "transports.netty.conf";
     protected List<ServerConnector> serverConnectors = new ArrayList<>();
     private EndpointsRegistryImpl endpointsRegistry = EndpointsRegistryImpl.getInstance();
     private MicroservicesRegistryImpl msRegistry = new MicroservicesRegistryImpl();
@@ -189,7 +193,8 @@ public class MicroservicesRunner {
      * @param ports The port on which the microservices are exposed
      */
     protected void configureTransport(int... ports) {
-        HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
+        HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl(Runtime.getRuntime()
+                .availableProcessors(), Runtime.getRuntime().availableProcessors() * 2);
         ServerBootstrapConfiguration bootstrapConfiguration = ServerBootstrapConfiguration.getInstance();
         for (int port : ports) {
             ListenerConfiguration listenerConfiguration = new ListenerConfiguration("netty-" + port, System
@@ -208,9 +213,10 @@ public class MicroservicesRunner {
      * Method to configure transports.
      */
     protected void configureTransport() {
-        HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
         String transportYaml = System.getProperty(TRANSPORTS_NETTY_CONF);
         if (transportYaml == null || transportYaml.isEmpty()) {
+            HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl(Runtime.getRuntime()
+                    .availableProcessors(), Runtime.getRuntime().availableProcessors() * 2);
             ServerBootstrapConfiguration bootstrapConfiguration = ServerBootstrapConfiguration.getInstance();
             ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
             ServerConnector serverConnector =
@@ -222,8 +228,17 @@ public class MicroservicesRunner {
         } else {
             TransportsConfiguration transportsConfiguration =
                     ConfigurationBuilder.getInstance().getConfiguration(transportYaml);
+            Map<String, Object> transportProperties = HTTPConnectorUtil.getTransportProperties(transportsConfiguration);
+            int bossGroup = transportProperties.get(Constants.SERVER_BOOTSTRAP_BOSS_GROUP_SIZE) != null ? (Integer)
+                    transportProperties.get(Constants.SERVER_BOOTSTRAP_BOSS_GROUP_SIZE) : Runtime.getRuntime()
+                    .availableProcessors();
+            int workerGroup = transportProperties.get(Constants.SERVER_BOOTSTRAP_WORKER_GROUP_SIZE) != null ? (Integer)
+                    transportProperties.get(Constants.SERVER_BOOTSTRAP_WORKER_GROUP_SIZE) : Runtime.getRuntime()
+                    .availableProcessors() * 2;
+            HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl(bossGroup, workerGroup);
             ServerBootstrapConfiguration serverBootstrapConfiguration =
                     HTTPConnectorUtil.getServerBootstrapConfiguration(transportsConfiguration.getTransportProperties());
+
             for (ListenerConfiguration listenerConfiguration : transportsConfiguration.getListenerConfigurations()) {
                 ServerConnector serverConnector =
                         connectorFactory.createServerConnector(serverBootstrapConfiguration, listenerConfiguration);

--- a/core/src/main/java/org/wso2/msf4j/Request.java
+++ b/core/src/main/java/org/wso2/msf4j/Request.java
@@ -49,8 +49,7 @@ public class Request {
         // find accept types
         String acceptHeaderStr = httpCarbonMessage.getHeader(javax.ws.rs.core.HttpHeaders.ACCEPT);
         acceptTypes = (acceptHeaderStr != null) ?
-                Arrays.asList(acceptHeaderStr.split("\\s*,\\s*"))
-                        .stream()
+                Arrays.stream(acceptHeaderStr.split("\\s*,\\s*"))
                         .map(mediaType -> mediaType.split("\\s*;\\s*")[0])
                         .collect(Collectors.toList()) :
                 null;

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
@@ -93,13 +93,11 @@ public class MSF4JHttpConnectorListener implements HttpConnectorListener {
             if (configProvider != null) {
                 msf4JConfig = DataHolder.getInstance().getConfigProvider().getConfigurationObject(MSF4JConfig.class);
             } else {
-                msf4JConfig = MSF4JConfig.class.newInstance();
+                msf4JConfig = new MSF4JConfig();
             }
         } catch (ConfigurationException e) {
             throw new RuntimeException("Error while loading " + MSF4JConfig.class.getName() + " from config provider",
                     e);
-        } catch (IllegalAccessException | InstantiationException e) {
-            throw new RuntimeException("Error while creating instance of the class " + MSF4JConfig.class.getName(), e);
         }
 
         executorService = Executors.newFixedThreadPool(msf4JConfig.getThreadCount(), new MSF4JThreadFactory(

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
@@ -173,7 +173,7 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
                     transportsConfiguration.getListenerConfigurations();
             if (listenerConfigurations.isEmpty()) {
                 listenerConfigurations = new HashSet<>();
-                listenerConfigurations.add(ListenerConfiguration.getDefault());
+                listenerConfigurations.add(new ListenerConfiguration());
             }
 
             ServerBootstrapConfiguration serverBootstrapConfiguration =

--- a/core/src/main/java/org/wso2/msf4j/internal/entitywriter/StreamingOutputEntityWriter.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/entitywriter/StreamingOutputEntityWriter.java
@@ -16,7 +16,6 @@
 
 package org.wso2.msf4j.internal.entitywriter;
 
-import io.netty.handler.codec.http.DefaultLastHttpContent;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.contract.ServerConnectorException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -58,7 +57,7 @@ public class StreamingOutputEntityWriter implements EntityWriter<StreamingOutput
             });
             OutputStream outputStream = new HttpMessageDataStreamer(carbonMessage).getOutputStream();
             output.write(outputStream);
-            carbonMessage.addHttpContent(new DefaultLastHttpContent());
+            outputStream.close();
         } catch (IOException e) {
             throw new RuntimeException("Error occurred while streaming output", e);
         }


### PR DESCRIPTION
## Purpose
This PR is to do following suggestion came in the code review,
* Don't use HttpWsConnectorFactory default constructor. initialize passing bossGroupsize and workerGroupSize
* Close the outputStream  in StreamingOutputEntityWriter after writing the content.
* Remove depreciate methods.

## Goals
To fix code review suggestions.

## Approach
* avoid using default constructor of HttpWsConnectorFactory class.
* Get bossGroupSize and WorkerGroupSize from the configuration. if not exists, get Runtime.avaliableProcessors.

## User stories
N/A

## Release note
This is a part of transport version upgrade in msf4j.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Already available

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04 with jdk 1.8.0.111
 
## Learning
transport implementation.