### PR TITLE
Bump transport-http and carbon-deployment versions

### DIFF
--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -739,8 +739,8 @@
         <carbon.config.package.import.version.range>[2.1.5, 3.0.0)</carbon.config.package.import.version.range>
         <carbon.secvault.version>5.0.8</carbon.secvault.version>
         <carbon.secvault.version.range>[5.0.0, 6.0.0)</carbon.secvault.version.range>
-        <carbon.deployment.version>5.1.5</carbon.deployment.version>
-        <carbon.deployment.version.range>[5.0.0,6.0.0)</carbon.deployment.version.range>
+        <carbon.deployment.version>5.1.9</carbon.deployment.version>
+        <carbon.deployment.version.range>[5.1.9, 6.0.0)</carbon.deployment.version.range>
         <carbon.messaging.version>3.0.2</carbon.messaging.version>
         <carbon.messaging.version.range>[3,4)</carbon.messaging.version.range>
         <carbon.jndi.version>1.0.4</carbon.jndi.version>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -745,8 +745,8 @@
         <carbon.messaging.version.range>[3,4)</carbon.messaging.version.range>
         <carbon.jndi.version>1.0.4</carbon.jndi.version>
         <carbon.datasources.version>1.1.3</carbon.datasources.version>
-        <org.wso2.transport.http.version>6.0.63</org.wso2.transport.http.version>
-        <org.wso2.transport.http.version.range>[6.0,7)</org.wso2.transport.http.version.range>
+        <org.wso2.transport.http.version>6.0.64</org.wso2.transport.http.version>
+        <org.wso2.transport.http.version.range>[6.0.64,7)</org.wso2.transport.http.version.range>
         <org.wso2.carbon.transport.http.netty.version>5.0.1</org.wso2.carbon.transport.http.netty.version>
         <org.apache.httpcomponents.httpclient.version>4.5.2</org.apache.httpcomponents.httpclient.version>
         <msf4j.version>2.5.1-SNAPSHOT</msf4j.version>


### PR DESCRIPTION
## Purpose
Bumps `transport.http` version to v6.0.64 and `carbon.deployment` version to v5.1.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
