### PR TITLE
Solve issue in Request.getSession() method, when extracting Cookie header

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/Request.java
+++ b/core/src/main/java/org/wso2/msf4j/Request.java
@@ -191,7 +191,7 @@ public class Request {
         }
         String cookieHeader = getHeader("Cookie");
         if (cookieHeader != null) {
-            session = Arrays.stream(cookieHeader.split(";"))
+            session = Arrays.stream(cookieHeader.split(";")).map(String::trim)
                     .filter(cookie -> cookie.startsWith(MSF4JConstants.SESSION_ID))
                     .findFirst()
                     .map(jsession -> sessionManager.getSession(jsession.substring(MSF4JConstants.SESSION_ID.length())))
@@ -217,7 +217,7 @@ public class Request {
         }
         String cookieHeader = getHeader("Cookie");
         if (cookieHeader != null) {
-            session = Arrays.stream(cookieHeader.split(";"))
+            session = Arrays.stream(cookieHeader.split(";")).map(String::trim)
                     .filter(cookie -> cookie.startsWith(MSF4JConstants.SESSION_ID))
                     .findFirst()
                     .map(jsession -> sessionManager.getSession(jsession.substring(MSF4JConstants.SESSION_ID.length())))


### PR DESCRIPTION
## Purpose
> This PR solve the issue when retrieving the JSESSIONID in the Cookie header. Related issue #452 

## Goals
> Resolve issue #452 

## Approach
> Use `.map(String::trim)` function when extracting Cookie header.

## User stories
> When there exist multiple Cookie values in Cookie header separated by `; `. 

> As an example when there is Cookie header like `Cookie:BSESSIONID=<cookie-value>;<space>JSESSIONID=<cookie-value>`, then `request.getSession()` function split and get the JSESSIONID. Since it doesn't trim, it unable to find out correct session and because of that, it creates a new session instead of getting the previous session.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> http-session

## Test environment
> java version "1.8.0_144" , OS - Linux Ubuntu, Browser - Chrome

  