### PR TITLE
Move stacktrace to debug level as some of the errors are harmless and can be ignored

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
@@ -265,6 +265,9 @@ public class MSF4JHttpConnectorListener implements HttpConnectorListener {
 
     @Override
     public void onError(Throwable throwable) {
-        log.error("Error in http connector listener", throwable);
+        // Adding stacktrace for debug level for better usability
+        log.warn("Error in http connector listener : '" + throwable.getMessage() + "'");
+        log.debug("Error in http connector listener", throwable);
+
     }
 }

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JHttpConnectorListener.java
@@ -268,6 +268,5 @@ public class MSF4JHttpConnectorListener implements HttpConnectorListener {
         // Adding stacktrace for debug level for better usability
         log.warn("Error in http connector listener : '" + throwable.getMessage() + "'");
         log.debug("Error in http connector listener", throwable);
-
     }
 }


### PR DESCRIPTION
## Purpose
Moving stack trace to debug level as some of the errors are harmless and can be ignored and this improves usability.

## Goals
Improve usability by changing log level to WARN as some of the errors are harmless 

## Approach
Changed log levels

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - Passes All
 - Integration tests - Passes All

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A
