### PR TITLE
Add support for transports >> http namespace

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -365,7 +365,8 @@
             org.wso2.carbon.kernel.startupresolver.*;version="${carbon.kernel.version.range}",
             org.wso2.carbon.config.*;version="${carbon.config.package.import.version.range}",
             org.wso2.transport.*;version="${org.wso2.transport.http.version.range}",
-            io.netty.*;version="${netty.version.range}"
+            io.netty.*;version="${netty.version.range}",
+            org.yaml.snakeyaml.*;version="${org.snakeyaml.version}"
         </import.package>
         <carbon.component>
             startup.listener;componentName="wso2-microservices-server";requiredService="org.wso2.msf4j.Microservice,org.wso2.msf4j.Interceptor,

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -19,11 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.msf4j.config.TransportsFileConfiguration;
 import org.wso2.msf4j.interceptor.RequestInterceptor;
 import org.wso2.msf4j.interceptor.ResponseInterceptor;
 import org.wso2.msf4j.internal.DataHolder;
 import org.wso2.msf4j.internal.HttpConnectorPortBindingListener;
+import org.wso2.msf4j.internal.MSF4JConstants;
 import org.wso2.msf4j.internal.MSF4JHttpConnectorListener;
 import org.wso2.msf4j.internal.MSF4JWSConnectorListener;
 import org.wso2.msf4j.internal.MicroservicesRegistryImpl;
@@ -46,6 +48,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.wso2.msf4j.internal.MSF4JConstants.STREAMLINED_TRANSPORT_NAMESPACE;
 
 /**
  * This runner initializes the microservices runtime, deploys the microservices and service interceptors,
@@ -234,9 +238,16 @@ public class MicroservicesRunner {
             serverConnectors.add(serverConnector);
         } else {
             try {
-                TransportsFileConfiguration transportsFileConfiguration =
-                        ConfigProviderFactory.getConfigProvider(Paths.get(transportYaml), null)
-                        .getConfigurationObject(TransportsFileConfiguration.class);
+                ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(Paths.get(transportYaml), null);
+                TransportsFileConfiguration transportsFileConfiguration;
+                Object transportConf = configProvider.getConfigurationObject(STREAMLINED_TRANSPORT_NAMESPACE);
+                if (transportConf != null) {
+                    transportsFileConfiguration = Utils.resolveTransportsNSConfiguration(transportConf);
+                } else {
+                    transportsFileConfiguration = configProvider.getConfigurationObject
+                            (MSF4JConstants.WSO2_TRANSPORT_HTTP_CONFIG_NAMESPACE, TransportsFileConfiguration.class);
+                }
+
                 TransportsConfiguration transportsConfiguration = Utils.
                         transformTransportConfiguration(transportsFileConfiguration);
 

--- a/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MSF4JConstants.java
@@ -24,6 +24,7 @@ public class MSF4JConstants {
     public static final String CHANNEL_ID = "listener.interface.id";
     public static final String CONTEXT_PATH = "contextPath";
     public static final String WSO2_TRANSPORT_HTTP_CONFIG_NAMESPACE = "wso2.transport.http";
+    public static final String STREAMLINED_TRANSPORT_NAMESPACE = "transports";
 
     // Property constants
     public static final String METHOD_PROPERTY_NAME = "method";

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
@@ -63,6 +63,8 @@ import java.util.Set;
 import javax.ws.rs.Path;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import static org.wso2.msf4j.internal.MSF4JConstants.STREAMLINED_TRANSPORT_NAMESPACE;
+
 /**
  * OSGi service component for MicroServicesServer.
  */
@@ -169,8 +171,15 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
     protected void registerConfigProvider(ConfigProvider configProvider) {
         DataHolder.getInstance().setConfigProvider(configProvider);
         try {
-            final TransportsFileConfiguration transportsFileConfiguration = configProvider.getConfigurationObject
-                    (MSF4JConstants.WSO2_TRANSPORT_HTTP_CONFIG_NAMESPACE, TransportsFileConfiguration.class);
+            final TransportsFileConfiguration transportsFileConfiguration;
+            Object transportConf = configProvider.getConfigurationObject(STREAMLINED_TRANSPORT_NAMESPACE);
+            if (transportConf != null) {
+                transportsFileConfiguration = Utils.resolveTransportsNSConfiguration(transportConf);
+            } else {
+                transportsFileConfiguration = configProvider.getConfigurationObject
+                        (MSF4JConstants.WSO2_TRANSPORT_HTTP_CONFIG_NAMESPACE, TransportsFileConfiguration.class);
+            }
+
             TransportsConfiguration transportsConfiguration =
                     Utils.transformTransportConfiguration(transportsFileConfiguration);
             Set<ListenerConfiguration> listenerConfigurations =

--- a/core/src/test/java/org/wso2/msf4j/TransportConfigurationTest2.java
+++ b/core/src/test/java/org/wso2/msf4j/TransportConfigurationTest2.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.msf4j;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.wso2.msf4j.conf.Constants;
+import org.wso2.msf4j.conf.SSLClientContext;
+import org.wso2.msf4j.exception.TestExceptionMapper;
+import org.wso2.msf4j.exception.TestExceptionMapper2;
+import org.wso2.msf4j.service.SecondService;
+import org.wso2.msf4j.service.TestMicroServiceWithDynamicPath;
+import org.wso2.msf4j.service.TestMicroservice;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URL;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.ws.rs.HttpMethod;
+
+/**
+ * Test the HttpsServer.
+ */
+public class TransportConfigurationTest2 extends HttpServerTest {
+
+    private static SSLClientContext sslClientContext;
+
+    private final TestMicroservice testMicroservice = new TestMicroservice();
+    private final SecondService secondService = new SecondService();
+    private MicroservicesRunner microservicesRunner;
+    private MicroservicesRunner secondMicroservicesRunner;
+
+    private static final int port = Constants.PORT + 4;
+
+
+    @BeforeClass
+    public void setup() throws Exception {
+        baseURI = URI.create(String.format("https://%s:%d", Constants.HOSTNAME, port));
+
+        System.setProperty("transports.netty.conf", Thread.currentThread().
+                getContextClassLoader().getResource("netty-transports-4.yaml").getPath());
+
+        microservicesRunner = new MicroservicesRunner();
+        sslClientContext = new SSLClientContext();
+        microservicesRunner
+                .addExceptionMapper(new TestExceptionMapper(), new TestExceptionMapper2())
+                .deploy(testMicroservice)
+                .start();
+        secondMicroservicesRunner = new MicroservicesRunner(port + 1);
+        secondMicroservicesRunner.deploy(secondService).start();
+        microservicesRunner.deploy("/DynamicPath", new TestMicroServiceWithDynamicPath());
+        microservicesRunner.deploy("/DynamicPath2", new TestMicroServiceWithDynamicPath());
+    }
+
+    @AfterClass
+    public void teardown() throws Exception {
+        microservicesRunner.stop();
+        secondMicroservicesRunner.stop();
+    }
+
+    @Override
+    protected HttpURLConnection request(String path, String method, boolean keepAlive) throws IOException {
+        URL url = baseURI.resolve(path).toURL();
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslClientContext.getClientContext().getSocketFactory());
+        HostnameVerifier allHostsValid = (hostname1, session) -> true;
+
+        // Install the all-trusting host verifier
+        HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+        HttpURLConnection urlConn = (HttpsURLConnection) url.openConnection();
+        if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT)) {
+            urlConn.setDoOutput(true);
+        }
+        urlConn.setRequestMethod(method);
+        if (!keepAlive) {
+            urlConn.setRequestProperty(HttpHeaderNames.CONNECTION.toString(), HEADER_VAL_CLOSE);
+        }
+        return urlConn;
+    }
+
+    @Override
+    protected Socket createRawSocket(URL url) throws IOException {
+        return sslClientContext.getClientContext().getSocketFactory().createSocket(url.getHost(), url.getPort());
+    }
+
+    static void setSslClientContext(SSLClientContext sslClientContext) {
+        TransportConfigurationTest2.sslClientContext = sslClientContext;
+    }
+}

--- a/core/src/test/resources/netty-transports-4.yaml
+++ b/core/src/test/resources/netty-transports-4.yaml
@@ -1,0 +1,43 @@
+################################################################################
+#   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+transports:
+  http:
+    transportProperties:
+     -
+      name: "latency.metrics.enabled"
+      value: true
+     -
+      name: "server.bootstrap.boss.group.size"
+      value: 4
+     -
+      name: "server.bootstrap.worker.group.size"
+      value: 8
+    listenerConfigurations:
+    -
+      id: "msf4j-http"
+      host: "127.0.0.1"
+      port: 8080
+    -
+      id: "jaxrs-http"
+      host: "0.0.0.0"
+      port: 8094
+      scheme: https
+      keyStoreFile: "src/test/resources/cert.jks"
+      keyStorePassword: secret
+      certPass: secret
+    senderConfigurations:
+     -
+      id: "netty-gw"

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -96,4 +96,11 @@ limitations under the License.
         </classes>
     </test>
 
+    <test name="configurations-test" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.msf4j.TransportConfigurationTest"/>
+            <class name="org.wso2.msf4j.TransportConfigurationTest2"/>
+        </classes>
+    </test>
+
 </suite>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -785,8 +785,8 @@
         <zipkin.brave.version>3.9.1</zipkin.brave.version>
         <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <carbon.metrics.version.range>[2.0,3)</carbon.metrics.version.range>
-        <carbon.analytics.common.version>5.0.6</carbon.analytics.common.version>
-        <carbon.analytics.common.version.range>[5.0,6)</carbon.analytics.common.version.range>
+        <carbon.analytics.common.version>6.1.30</carbon.analytics.common.version>
+        <carbon.analytics.common.version.range>[6.0,7)</carbon.analytics.common.version.range>
         <disruptor.orbit.version>3.3.2.wso2v2</disruptor.orbit.version>
         <metrics.version>3.1.2</metrics.version>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -785,8 +785,8 @@
         <zipkin.brave.version>3.9.1</zipkin.brave.version>
         <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <carbon.metrics.version.range>[2.0,3)</carbon.metrics.version.range>
-        <carbon.analytics.common.version>6.1.30</carbon.analytics.common.version>
-        <carbon.analytics.common.version.range>[6.0,7)</carbon.analytics.common.version.range>
+        <carbon.analytics.common.version>5.0.6</carbon.analytics.common.version>
+        <carbon.analytics.common.version.range>[5.0,6)</carbon.analytics.common.version.range>
         <disruptor.orbit.version>3.3.2.wso2v2</disruptor.orbit.version>
         <metrics.version>3.1.2</metrics.version>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>


### PR DESCRIPTION
## Purpose
$subject
```
transports:
  http:
    transportProperties:
     -
      name: "latency.metrics.enabled"
      value: true
     -
      name: "server.bootstrap.boss.group.size"
      value: 4
     -
      name: "server.bootstrap.worker.group.size"
      value: 8
    listenerConfigurations:
    -
      id: "msf4j-http"
      host: "127.0.0.1"
      port: 8080
    -
      id: "jaxrs-http"
      host: "0.0.0.0"
      port: 8094
      scheme: https
      keyStoreFile: "src/test/resources/cert.jks"
      keyStorePassword: secret
      certPass: secret
    senderConfigurations:
     -
      id: "netty-gw"

```

## Goals
To streamline configurations as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8

## Documentation
N/A as it is backward compatible

## Automation tests
 - Unit tests - Passes All
 - Integration tests - Passess All

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes