### PR TITLE
 Add support for wso2.carbon >> ports >> offset

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -363,6 +363,7 @@
             org.osgi.framework.*;version="${osgi.framework.import.version.range}",
             org.osgi.util.tracker; version="${osgi.service.tracker.import.version.range}",
             org.wso2.carbon.kernel.startupresolver.*;version="${carbon.kernel.version.range}",
+            org.wso2.carbon.kernel.config.model.*;version="${carbon.kernel.version.range}",
             org.wso2.carbon.config.*;version="${carbon.config.package.import.version.range}",
             org.wso2.transport.*;version="${org.wso2.transport.http.version.range}",
             io.netty.*;version="${netty.version.range}",

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.msf4j.config.TransportsFileConfiguration;
 import org.wso2.msf4j.interceptor.RequestInterceptor;
 import org.wso2.msf4j.interceptor.ResponseInterceptor;
@@ -250,6 +251,11 @@ public class MicroservicesRunner {
 
                 TransportsConfiguration transportsConfiguration = Utils.
                         transformTransportConfiguration(transportsFileConfiguration);
+
+                CarbonConfiguration carbonConfig = configProvider.getConfigurationObject(CarbonConfiguration.class);
+                transportsConfiguration.getListenerConfigurations().forEach(
+                        listenerConfiguration -> listenerConfiguration.setPort(
+                                listenerConfiguration.getPort() + carbonConfig.getPortsConfig().getOffset()));
 
                 Map<String, Object> transportProperties = HttpConnectorUtil
                         .getTransportProperties(transportsConfiguration);

--- a/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
+++ b/core/src/main/java/org/wso2/msf4j/MicroservicesRunner.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
-import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.msf4j.config.TransportsFileConfiguration;
 import org.wso2.msf4j.interceptor.RequestInterceptor;
 import org.wso2.msf4j.interceptor.ResponseInterceptor;
@@ -251,11 +250,6 @@ public class MicroservicesRunner {
 
                 TransportsConfiguration transportsConfiguration = Utils.
                         transformTransportConfiguration(transportsFileConfiguration);
-
-                CarbonConfiguration carbonConfig = configProvider.getConfigurationObject(CarbonConfiguration.class);
-                transportsConfiguration.getListenerConfigurations().forEach(
-                        listenerConfiguration -> listenerConfiguration.setPort(
-                                listenerConfiguration.getPort() + carbonConfig.getPortsConfig().getOffset()));
 
                 Map<String, Object> transportProperties = HttpConnectorUtil
                         .getTransportProperties(transportsConfiguration);

--- a/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/MicroservicesServerSC.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
+import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.kernel.startupresolver.StartupServiceUtils;
 import org.wso2.msf4j.DefaultSessionManager;
@@ -182,6 +183,12 @@ public class MicroservicesServerSC implements RequiredCapabilityListener {
 
             TransportsConfiguration transportsConfiguration =
                     Utils.transformTransportConfiguration(transportsFileConfiguration);
+
+            CarbonConfiguration carbonConfig = configProvider.getConfigurationObject(CarbonConfiguration.class);
+            transportsConfiguration.getListenerConfigurations().forEach(
+                    listenerConfiguration -> listenerConfiguration.setPort(
+                            listenerConfiguration.getPort() + carbonConfig.getPortsConfig().getOffset()));
+
             Set<ListenerConfiguration> listenerConfigurations =
                     transportsConfiguration.getListenerConfigurations();
             if (listenerConfigurations.isEmpty()) {

--- a/tests/osgi-tests/src/test/java/org/wso2/msf4j/osgi/test/MSF4JOSGiTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/msf4j/osgi/test/MSF4JOSGiTest.java
@@ -59,7 +59,7 @@ public class MSF4JOSGiTest {
     private static final String HEADER_VAL_CLOSE = "CLOSE";
 
     private static final String HOSTNAME = "localhost";
-    private static final int PORT = 8080;
+    private static final int PORT = 8079;
 
     @Inject
     private CarbonServerInfo carbonServerInfo;

--- a/tests/test-distribution/carbon-home/conf/deployment.yaml
+++ b/tests/test-distribution/carbon-home/conf/deployment.yaml
@@ -21,7 +21,7 @@ wso2.carbon:
     # ports used by this server
   ports:
       # port offset
-    offset: 0
+    offset: -1
 
 wso2.securevault:
   secretRepository:


### PR DESCRIPTION
## Purpose
When TransportsConfiguration is not given in the API, this supports setting ports offset through wso2.carbon namespace
```yaml
  # Carbon Configuration Parameters
wso2.carbon:
    # value to uniquely identify a server
  id: siddhi-runner
    # server name
  name: Siddhi Runner Distribution
    # ports used by this server
  ports:
      # port offset
    offset: 1

```
## Goals
Support port offset in carbon configuration

## Approach
As in 45f45d0

## Release note
Support port offset under carbon configuration if present

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes