### PR TITLE
Bundle javax.annotation dependecy for JDK 11 support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,8 +113,10 @@
             <groupId>org.wso2.carbon.config</groupId>
             <artifactId>org.wso2.carbon.config</artifactId>
         </dependency>
-
-
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>

--- a/features/org.wso2.msf4j.feature/pom.xml
+++ b/features/org.wso2.msf4j.feature/pom.xml
@@ -204,6 +204,10 @@
             <groupId>org.wso2.carbon.messaging</groupId>
             <artifactId>org.wso2.carbon.messaging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -248,6 +252,10 @@
                                 <bundle>
                                     <symbolicName>jaxrs-delegates</symbolicName>
                                     <version>${msf4j.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>javax.annotation-api</symbolicName>
+                                    <version>${javax.annotation.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>msf4j-swagger</symbolicName>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -540,6 +540,11 @@
                 <version>${javax.validation.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${apache.commons.lang3.version}</version>
@@ -798,6 +803,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.5</httpcore.version>
         <javax.websocket.version>1.1</javax.websocket.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
 
         <osgi.api.version>6.0.0</osgi.api.version>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>


### PR DESCRIPTION
## Purpose
> Commons Annotation in the package javax.annotation has been removed with deprecation of Java EE Modules in JDK 11. Hence, bundling the third-party dependency.