### PR TITLE
Bump netty version

### DIFF
--- a/analytics/msf4j-analytics-common/pom.xml
+++ b/analytics/msf4j-analytics-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/analytics/msf4j-analytics/pom.xml
+++ b/analytics/msf4j-analytics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/analytics/wso2das-tracing-capp/pom.xml
+++ b/analytics/wso2das-tracing-capp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/analytics/zipkin-tracing/pom.xml
+++ b/analytics/zipkin-tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/archetypes/msf4j-microservice/pom.xml
+++ b/archetypes/msf4j-microservice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/binary/pom.xml
+++ b/distribution/binary/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/distribution/msf4j-all/pom.xml
+++ b/distribution/msf4j-all/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.msf4j.deployer.feature/pom.xml
+++ b/features/org.wso2.msf4j.deployer.feature/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.msf4j.feature/pom.xml
+++ b/features/org.wso2.msf4j.feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/jaxrs-delegates/pom.xml
+++ b/jaxrs-delegates/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/perf-benchmark/Samples/wso2msf4j/pom.xml
+++ b/perf-benchmark/Samples/wso2msf4j/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 
     <groupId>org.wso2.msf4j.perftest.echo</groupId>
     <artifactId>wso2msf4j-echo-message</artifactId>
-    <version>2.7.6</version>
+    <version>2.7.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>WSO2 MSF4J Microservice benchmark service</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
     <groupId>org.wso2.msf4j</groupId>
     <artifactId>msf4j</artifactId>
     <packaging>pom</packaging>
-    <version>2.7.6</version>
+    <version>2.7.7-SNAPSHOT</version>
 
     <scm>
         <url>https://github.com/wso2/msf4j.git</url>
         <developerConnection>scm:git:https://github.com/wso2/msf4j.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/msf4j.git</connection>
-        <tag>v2.7.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/poms/msf4j-service/pom.xml
+++ b/poms/msf4j-service/pom.xml
@@ -20,7 +20,7 @@
     <groupId>org.wso2.msf4j</groupId>
     <artifactId>msf4j-service</artifactId>
     <packaging>pom</packaging>
-    <version>2.7.6</version>
+    <version>2.7.7-SNAPSHOT</version>
 
     <name>MSF4J-Parent</name>
 
@@ -151,7 +151,7 @@
         <connection>scm:git:https://github.com/wso2/carbon-parent.git</connection>
         <url>https://github.com/wso2/carbon-parent.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-parent.git</developerConnection>
-        <tag>v2.7.6</tag>
+        <tag>carbon-parent-4</tag>
     </scm>
 
     <build>
@@ -574,7 +574,7 @@
         <!-- Other dependency versions -->
         <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
 
-        <msf4j.version>2.7.6</msf4j.version>
+        <msf4j.version>2.7.7-SNAPSHOT</msf4j.version>
 
         <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>
         <wso2.maven.compiler.target>1.8</wso2.maven.compiler.target>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -757,7 +757,7 @@
         <maven.archetype.version>2.4</maven.archetype.version>
 
         <!-- Dependencies -->
-        <netty.version>4.1.19.Final</netty.version>
+        <netty.version>4.1.34.Final</netty.version>
         <netty.version.range>(4,5]</netty.version.range>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
         <carbon.kernel.version>5.2.0</carbon.kernel.version>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.msf4j</groupId>
     <artifactId>msf4j-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.7.6</version>
+    <version>2.7.7-SNAPSHOT</version>
     <name>WSO2 MSF4J - Parent Pom</name>
     <description>WSO2 MSF4J Parent Pom</description>
     <url>http://wso2.org</url>
@@ -781,7 +781,7 @@
         <javax.websocket.version>1.1</javax.websocket.version>
         <javax.websocket.version.range>[1.1, 1.2)</javax.websocket.version.range>
         <org.apache.httpcomponents.httpclient.version>4.5.2</org.apache.httpcomponents.httpclient.version>
-        <msf4j.version>2.7.6</msf4j.version>
+        <msf4j.version>2.7.7-SNAPSHOT</msf4j.version>
         <zipkin.brave.version>3.9.1</zipkin.brave.version>
         <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <carbon.metrics.version.range>[2.0,3)</carbon.metrics.version.range>
@@ -880,8 +880,4 @@
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
         <org.osgi.compendium.version>4.3.1</org.osgi.compendium.version>
     </properties>
-
-  <scm>
-    <tag>v2.7.6</tag>
-  </scm>
 </project>

--- a/samples/basicauth-security/pom.xml
+++ b/samples/basicauth-security/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/circuitbreaker/pom.xml
+++ b/samples/circuitbreaker/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/fileserver/pom.xml
+++ b/samples/fileserver/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/formparam/pom.xml
+++ b/samples/formparam/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/helloworld/pom.xml
+++ b/samples/helloworld/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/http-monitoring/pom.xml
+++ b/samples/http-monitoring/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/http-session/pom.xml
+++ b/samples/http-session/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/interceptor/deployable-jar-interceptor-service/pom.xml
+++ b/samples/interceptor/deployable-jar-interceptor-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/interceptor/fatjar-interceptor-service/pom.xml
+++ b/samples/interceptor/fatjar-interceptor-service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -59,7 +59,7 @@
     </build>
 
     <properties>
-        <interceptor-common.version>2.7.6</interceptor-common.version>
+        <interceptor-common.version>2.7.7-SNAPSHOT</interceptor-common.version>
         <microservice.mainClass>org.wso2.msf4j.samples.fatjarinterceptorservice.Application</microservice.mainClass>
     </properties>
 </project>

--- a/samples/interceptor/interceptor-common/pom.xml
+++ b/samples/interceptor/interceptor-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/interceptor/osgi-interceptor-service/pom.xml
+++ b/samples/interceptor/osgi-interceptor-service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/parent/pom.xml</relativePath>
     </parent>
 
@@ -64,7 +64,7 @@
     </dependencies>
 
     <properties>
-        <interceptor-common.version>2.7.6</interceptor-common.version>
+        <interceptor-common.version>2.7.7-SNAPSHOT</interceptor-common.version>
         <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
         <import.package>
             org.osgi.framework.*;version="${osgi.framework.import.version.range}",

--- a/samples/jpa/pom.xml
+++ b/samples/jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/jwt-claims/JWTAccessTokenBuilder/pom.xml
+++ b/samples/jwt-claims/JWTAccessTokenBuilder/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>jwt-claims</artifactId>
         <groupId>org.wso2.msf4j</groupId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/samples/jwt-claims/jwt-sample/pom.xml
+++ b/samples/jwt-claims/jwt-sample/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>msf4j-service</artifactId>
         <groupId>org.wso2.msf4j</groupId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/jwt-claims/pom.xml
+++ b/samples/jwt-claims/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
+++ b/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.wso2.msf4j</groupId>
     <artifactId>sso-agent-sample-webapp</artifactId>
-    <version>2.7.6</version>
+    <version>2.7.7-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Travelocity.COM ServiceProvider / RelyingParty Webapp</name>
 

--- a/samples/lifecycle/pom.xml
+++ b/samples/lifecycle/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/message-tracing/das/pom.xml
+++ b/samples/message-tracing/das/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/message-tracing/zipkin/pom.xml
+++ b/samples/message-tracing/zipkin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/metrics/pom.xml
+++ b/samples/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/oauth2-security/pom.xml
+++ b/samples/oauth2-security/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/microservices/fileserver/pom.xml
+++ b/samples/petstore/microservices/fileserver/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/microservices/pet/pom.xml
+++ b/samples/petstore/microservices/pet/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/microservices/security/pom.xml
+++ b/samples/petstore/microservices/security/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/microservices/transaction/pom.xml
+++ b/samples/petstore/microservices/transaction/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/pom.xml
+++ b/samples/petstore/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/samples/petstore/util/pom.xml
+++ b/samples/petstore/util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>petstore</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/samples/regex-pathparam/pom.xml
+++ b/samples/regex-pathparam/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/spring-helloworld/pom.xml
+++ b/samples/spring-helloworld/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-spring</artifactId>
-            <version>2.7.6</version>
+            <version>2.7.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <properties>

--- a/samples/spring-profile/pom.xml
+++ b/samples/spring-profile/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-spring</artifactId>
-            <version>2.7.6</version>
+            <version>2.7.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <properties>

--- a/samples/stockquote/bundle/pom.xml
+++ b/samples/stockquote/bundle/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/parent/pom.xml</relativePath>
     </parent>
 
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-swagger</artifactId>
-            <version>2.7.6</version>
+            <version>2.7.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/samples/stockquote/deployable-jar/pom.xml
+++ b/samples/stockquote/deployable-jar/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/stockquote/fatjar/pom.xml
+++ b/samples/stockquote/fatjar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-swagger</artifactId>
-            <version>2.7.6</version>
+            <version>2.7.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/samples/subresource/pom.xml
+++ b/samples/subresource/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/template/pom.xml
+++ b/samples/template/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-mustache-template</artifactId>
-            <version>2.7.6</version>
+            <version>2.7.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/samples/websocket/chatApp/bundle/pom.xml
+++ b/samples/websocket/chatApp/bundle/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/samples/websocket/chatApp/deployable-jar/pom.xml
+++ b/samples/websocket/chatApp/deployable-jar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/websocket/chatApp/fatjar/pom.xml
+++ b/samples/websocket/chatApp/fatjar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-service</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../../../poms/msf4j-service/pom.xml</relativePath>
     </parent>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/templating/msf4j-mustache-template/pom.xml
+++ b/templating/msf4j-mustache-template/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-tests</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-parent</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../poms/parent/pom.xml</relativePath>
     </parent>
 

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.msf4j</groupId>
         <artifactId>msf4j-tests</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Purpose
This PR upgrades netty version from 4.1.19.Final to 4.1.34.Final and also prepares repo for next development iteration.  

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes