### PR TITLE
Could org.wso2.msf4j:sso-agent-sample-webapp:2.8.4-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
+++ b/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
@@ -34,17 +34,37 @@
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
             <version>1.4.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>xmltooling</artifactId>
             <version>1.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.jcip</groupId>
+                    <artifactId>jcip-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jul-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
@@ -64,12 +84,34 @@
                     <groupId>commons-collections.wso2</groupId>
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.oltu.oauth2</groupId>
+                    <artifactId>org.apache.oltu.oauth2.client</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
             <version>1.2.11-wso2v6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
@lasanthaS  Hi, I am a user of project **_org.wso2.msf4j:sso-agent-sample-webapp:2.8.4-SNAPSHOT_**. I found that its pom file introduced **_46_** dependencies. However, among them, **_9_** libraries (**_19%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.wso2.msf4j:sso-agent-sample-webapp:2.8.4-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
net.jcip:jcip-annotations:jar:1.0:compile
org.json:json:jar:20131018:compile
org.apache.oltu.oauth2:org.apache.oltu.oauth2.common:jar:1.0.0:compile
org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
xml-apis:xml-apis:jar:1.3.04:compile
org.slf4j:jul-to-slf4j:jar:1.6.1:compile
org.apache.geronimo.specs:geronimo-activation_1.1_spec:jar:1.0.2:compile
org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:jar:1.0.0:compile
</code></pre>