### PR TITLE
Upgrade Netty components

### DIFF
--- a/features/org.wso2.msf4j.feature/pom.xml
+++ b/features/org.wso2.msf4j.feature/pom.xml
@@ -201,6 +201,10 @@
             <artifactId>netty-codec-socks</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.messaging</groupId>
             <artifactId>org.wso2.carbon.messaging</artifactId>
         </dependency>
@@ -359,6 +363,10 @@
                                     <version>${netty-tcnative.version}</version>
                                 </bundle>
                                 <bundle>
+                                    <symbolicName>io.netty.tcnative-classes</symbolicName>
+                                    <version>${netty-tcnative.version}</version>
+                                </bundle>
+                                <bundle>
                                     <symbolicName>io.netty.handler</symbolicName>
                                     <version>${netty.version}</version>
                                 </bundle>
@@ -372,6 +380,10 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>io.netty.resolver</symbolicName>
+                                    <version>${netty.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>io.netty.transport-native-unix-common</symbolicName>
                                     <version>${netty.version}</version>
                                 </bundle>
 

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -316,7 +316,17 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>${netty-tcnative.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-classes</artifactId>
                 <version>${netty-tcnative.version}</version>
             </dependency>
             <!--Test Distribution-->
@@ -767,8 +777,8 @@
         <maven.archetype.version>2.4</maven.archetype.version>
 
         <!-- Dependencies -->
-        <netty.version>4.1.74.Final</netty.version>
-        <netty-tcnative.version>2.0.45.Final</netty-tcnative.version>
+        <netty.version>4.1.81.Final</netty.version>
+        <netty-tcnative.version>2.0.54.Final</netty-tcnative.version>
         <netty.version.range>(4,5]</netty.version.range>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
         <carbon.kernel.version>5.2.0</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
When we start a SI or SI tooling 4.1.0 pack on aarch64 architecture, an error is thrown due to an issue in netty components below version 4.1.79.Final. Since MSF4J is packing the netty components to SI and SI tooling, This PR will upgrade the netty version to `4.1.81.Final` and netty-tcnative version to `2.0.54.Final`. To ensure the upgrade compatibility, we need to add the following new dependencies as well,
- netty-transport-native-unix-common
- netty-tcnative-classes

Fixes https://github.com/wso2/api-manager/issues/723



