### PR TITLE
Upgrade netty to 4.1.86.Final

### DIFF
--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -782,7 +782,7 @@
         <maven.archetype.version>2.4</maven.archetype.version>
 
         <!-- Dependencies -->
-        <netty.version>4.1.81.Final</netty.version>
+        <netty.version>4.1.86.Final</netty.version>
         <netty-tcnative.version>2.0.54.Final</netty-tcnative.version>
         <netty.version.range>(4,5]</netty.version.range>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>


### PR DESCRIPTION
## Purpose
This PR upgrades all `io.netty` dependencies to `4.1.86.Final` for https://github.com/wso2/api-manager/issues/1243