### PR TITLE
Upgrade Version Ranges of Dependencies

### DIFF
--- a/features/org.wso2.msf4j.feature/pom.xml
+++ b/features/org.wso2.msf4j.feature/pom.xml
@@ -69,7 +69,7 @@
             <artifactId>failureaccess</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>org.wso2.orbit.io.swagger.core</groupId>
             <artifactId>swagger-core</artifactId>
             <exclusions>
                 <exclusion>
@@ -83,7 +83,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>org.wso2.orbit.io.swagger.jaxrs</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
@@ -99,16 +99,6 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-models</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -290,20 +280,16 @@
                                     <version>${beanutils.osgi.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>io.swagger.core</symbolicName>
-                                    <version>${io.swagger.version}</version>
+                                    <symbolicName>swagger-core</symbolicName>
+                                    <version>${swagger.orbit.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>io.swagger.annotations</symbolicName>
                                     <version>${io.swagger.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>io.swagger.jaxrs</symbolicName>
-                                    <version>${io.swagger.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>io.swagger.models</symbolicName>
-                                    <version>${io.swagger.version}</version>
+                                    <symbolicName>swagger-jaxrs</symbolicName>
+                                    <version>${swagger.orbit.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>com.fasterxml.jackson.core.jackson-databind</symbolicName>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -475,20 +475,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-models</artifactId>
-                <version>${io.swagger.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.swagger</groupId>
+                <groupId>org.wso2.orbit.io.swagger.core</groupId>
                 <artifactId>swagger-core</artifactId>
-                <version>${io.swagger.version}</version>
+                <version>${swagger.orbit.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -509,9 +498,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.swagger</groupId>
+                <groupId>org.wso2.orbit.io.swagger.jaxrs</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
-                <version>${io.swagger.version}</version>
+                <version>${swagger.orbit.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.ws.rs</groupId>
@@ -836,9 +825,9 @@
         <slf4j.log4j.version>1.6.0</slf4j.log4j.version>
         <gson.version>2.9.1</gson.version>
         <gson.version.range>[2.2,3)</gson.version.range>
-        <guava.version>31.1-jre</guava.version>
-        <guava.bundle.version>31.1.0.jre</guava.bundle.version>
-        <guava.version.range>[20.0,32.0)</guava.version.range>
+        <guava.version>32.1.3-jre</guava.version>
+        <guava.bundle.version>32.1.3.jre</guava.bundle.version>
+        <guava.version.range>[20.0,34.0)</guava.version.range>
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
         <jsr305.version>2.0.1</jsr305.version>
         <beanutils.version>1.8.3_2</beanutils.version>
@@ -846,15 +835,16 @@
         <beanutils.osgi.version>1.8.3.2</beanutils.osgi.version>
         <logback.version>1.0.9</logback.version>
         <nimbus.jose.jwt.version>2.25</nimbus.jose.jwt.version>
-        <io.swagger.version>1.6.7</io.swagger.version>
+        <io.swagger.version>1.6.9</io.swagger.version>
+        <swagger.orbit.version>1.6.9.wso2v2</swagger.orbit.version>
         <io.swagger.version.range>[1.5.16,1.7.0)</io.swagger.version.range>
-        <com.fasterxml.jackson.version>2.14.1</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.14.1</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.version.range>[2.13.0,2.15.0)</com.fasterxml.jackson.version.range>
+        <com.fasterxml.jackson.version>2.16.0</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.16.0</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.version.range>[2.15.0,2.17.0)</com.fasterxml.jackson.version.range>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
         <apache.commons.lang3.version>3.4</apache.commons.lang3.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <reflections.orbit.version>0.9.11.wso2v3</reflections.orbit.version>
+        <reflections.orbit.version>0.9.11.wso2v4</reflections.orbit.version>
         <javassist.version>3.19.0-GA</javassist.version>
 
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
@@ -892,7 +882,7 @@
         <equinox.simpleconfigurator.manipulator.version>2.0.0.v20131217-1203
         </equinox.simpleconfigurator.manipulator.version>
         <equinox.util.version>1.0.500.v20130404-1337</equinox.util.version>
-        <org.snakeyaml.version>1.33</org.snakeyaml.version>
+        <org.snakeyaml.version>2.2</org.snakeyaml.version>
         <equinox.simpleconfigurator.version>1.1.0.v20131217-1203</equinox.simpleconfigurator.version>
         <testng.version>6.9.4</testng.version>
         <maven.paxexam.plugin.version>1.2.4</maven.paxexam.plugin.version>

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>org.wso2.orbit.io.swagger.core</groupId>
             <artifactId>swagger-core</artifactId>
             <exclusions>
                 <exclusion>
@@ -70,7 +70,7 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.swagger</groupId>
+            <groupId>org.wso2.orbit.io.swagger.jaxrs</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### Purpose
- Upgrade version ranges of the following dependencies
  - guava
  - jackson-databind
  - reflections
  - snakeyaml
- Use the orbit bundles of swagger-core [1] and swagger-jaxrs [2] for version 1.6.9

[1] https://github.com/wso2/orbit/tree/master/swagger-core/1.6.9.wso2v2
[2] https://github.com/wso2/orbit/tree/master/swagger-jaxrs/1.6.9.wso2v2