### PR TITLE
Handle URI parsing exception in PatternPathRouter to return a bad request

### DIFF
--- a/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
+++ b/core/src/main/java/org/wso2/msf4j/internal/router/MicroserviceMetadata.java
@@ -186,6 +186,9 @@ public final class MicroserviceMetadata {
         } catch (NoSuchElementException ex) {
             throw new HandlerException(Response.Status.UNSUPPORTED_MEDIA_TYPE,
                     String.format("Problem accessing: %s. Reason: Unsupported Media Type", uri), ex);
+        } catch (IllegalArgumentException ex) {
+            throw new HandlerException(Response.Status.BAD_REQUEST,
+                    String.format("Problem accessing: %s. Reason: Bad Request", uri), ex);
         }
     }
 


### PR DESCRIPTION
## Purpose
> Add a change to handle URI parsing exception in PatternPathRouter to return a bad request instead of an internal server error from the global handler.
