### PR TITLE
Bump jackson and snackyaml versions

### DIFF
--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -858,9 +858,9 @@
         <io.swagger.version>1.6.9</io.swagger.version>
         <swagger.orbit.version>1.6.9.wso2v2</swagger.orbit.version>
         <io.swagger.version.range>[1.5.16,1.7.0)</io.swagger.version.range>
-        <com.fasterxml.jackson.version>2.16.0</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.16.0</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.version.range>[2.15.0,2.17.0)</com.fasterxml.jackson.version.range>
+        <com.fasterxml.jackson.version>2.18.6</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.version.range>[2.15.0,2.21.0)</com.fasterxml.jackson.version.range>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
         <apache.commons.lang3.version>3.4</apache.commons.lang3.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
@@ -902,7 +902,7 @@
         <equinox.simpleconfigurator.manipulator.version>2.0.0.v20131217-1203
         </equinox.simpleconfigurator.manipulator.version>
         <equinox.util.version>1.0.500.v20130404-1337</equinox.util.version>
-        <org.snakeyaml.version>2.2</org.snakeyaml.version>
+        <org.snakeyaml.version>2.3</org.snakeyaml.version>
         <equinox.simpleconfigurator.version>1.1.0.v20131217-1203</equinox.simpleconfigurator.version>
         <testng.version>6.9.4</testng.version>
         <maven.paxexam.plugin.version>1.2.4</maven.paxexam.plugin.version>

--- a/poms/parent/pom.xml
+++ b/poms/parent/pom.xml
@@ -860,7 +860,7 @@
         <io.swagger.version.range>[1.5.16,1.7.0)</io.swagger.version.range>
         <com.fasterxml.jackson.version>2.18.6</com.fasterxml.jackson.version>
         <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
-        <com.fasterxml.jackson.version.range>[2.15.0,2.21.0)</com.fasterxml.jackson.version.range>
+        <com.fasterxml.jackson.version.range>[2.15.0,2.18.6]</com.fasterxml.jackson.version.range>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
         <apache.commons.lang3.version>3.4</apache.commons.lang3.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>


### PR DESCRIPTION
## Purpose
$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Jackson to 2.18.6 and broadened its supported compatibility range to allow newer 2.x releases.
  * Updated SnakeYAML to 2.3.
  * These managed dependency updates ensure downstream components use the newer/parity versions of JSON and YAML libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->