### PR TITLE
Add msf4j-spring to dependencyManagement in msf4j-service POM

### DIFF
--- a/poms/msf4j-service/pom.xml
+++ b/poms/msf4j-service/pom.xml
@@ -493,6 +493,11 @@
                 <artifactId>msf4j-client</artifactId>
                 <version>${msf4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.msf4j</groupId>
+                <artifactId>msf4j-spring</artifactId>
+                <version>${msf4j.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary

- `samples/spring-helloworld` and `samples/spring-profile` declare `msf4j-spring` as a dependency without an explicit `<version>`, relying on the parent POM's dependency management to provide it
- `poms/msf4j-service/pom.xml` (the parent for these samples) was missing `msf4j-spring` in its `<dependencyManagement>` section, while other msf4j artifacts (`msf4j-core`, `msf4j-analytics`, `msf4j-swagger`, etc.) were already listed
- This caused a `ProjectBuildingException` during the Maven build: `'dependencies.dependency.version' for org.wso2.msf4j:msf4j-spring:jar is missing`

## Fix

Added `msf4j-spring` with `${msf4j.version}` to the `<dependencyManagement>` section in `poms/msf4j-service/pom.xml`, consistent with the other msf4j artifacts managed there.

Note: `deployer/pom.xml` also uses `msf4j-spring` without a version, but its parent is `msf4j-parent` (`poms/parent/pom.xml`) which already includes `msf4j-spring` in dependency management — so it is unaffected.

## Test plan

- [ ] Run `mvn clean install` from the repo root and verify the build succeeds
- [ ] Confirm `samples/spring-helloworld` and `samples/spring-profile` build without version-missing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)