### PR TITLE
Pass maven.repo.local to surefire for deployer tests

### DIFF
--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -91,6 +91,7 @@
                     <systemPropertyVariables>
                         <maven.home>${maven.home}</maven.home>
                         <project.filepath>${project.basedir}</project.filepath>
+                        <maven.repo.local>${maven.repo.local}</maven.repo.local>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary

- `MSF4JDeployerTest` uses Maven Invoker to fork separate Maven processes to build `samples/stockquote/bundle` and `samples/stockquote/deployable-jar` as part of the deployer integration tests
- The invoker already reads `maven.repo.local` system property and sets the local repository directory accordingly — but surefire was not passing that property to the test JVM
- Without it, the forked Maven process uses a different (empty) local repo, cannot find the cached `org.wso2:wso2:pom:5.3` artifact, falls back to Maven Central, and fails with a TLS handshake error on the Java 8 build environment
- This caused `testBundleArtifactDeployment` and `testJarArtifactDeployment` to fail with `NoSuchFileException` on the `target` directory (since the samples never built)

## Fix

Added `<maven.repo.local>${maven.repo.local}</maven.repo.local>` to surefire's `systemPropertyVariables` in `deployer/pom.xml`. This ensures the Maven Invoker in the test uses the same local repository as the main build, where all parent POMs are already cached.

## Test plan

- [ ] Run `mvn clean install` from the repo root and verify `msf4j-deployer` tests pass
- [ ] Confirm `testBundleArtifactDeployment` and `testJarArtifactDeployment` no longer fail with `NoSuchFileException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)