### PR TITLE
Fix maven-release-plugin failure in template sample (msf4j.version to project.version)

### DIFF
--- a/samples/template/pom.xml
+++ b/samples/template/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.wso2.msf4j</groupId>
             <artifactId>msf4j-mustache-template</artifactId>
-            <version>${msf4j.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

- \`samples/template/pom.xml\` used \`\${msf4j.version}\` for its \`msf4j-mustache-template\` dependency version
- maven-release-plugin 2.5.3 only looks for property definitions in the **current module's own \`<properties>\` section** — it does not traverse parent POMs
- Since \`template/pom.xml\` has no \`msf4j.version\` in its own \`<properties>\`, \`release:prepare\` threw \`ReleaseFailureException: The version could not be updated: \${msf4j.version}\` when processing this module, blocking the 2.9.0 release
- Fix: replace \`\${msf4j.version}\` with \`\${project.version}\`, which the release plugin handles via a dedicated code path that requires no local property lookup; with \`autoVersionSubmodules=true\` all modules share the same release version so this is semantically equivalent

## Test plan

- [x] \`mvn release:prepare -DdryRun=true -DdevelopmentVersion=2.9.1-SNAPSHOT -DreleaseVersion=2.9.0 -Dtag=v2.9.0 -Dmaven.test.skip=true -Dresume=false\` completes with \`BUILD SUCCESS\`
- [ ] Re-trigger Jenkins release pipeline for 2.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)