### PR TITLE
Fix Javadoc failure on sso-agent-sample-webapp under JDK 11

### DIFF
--- a/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
+++ b/samples/jwt-claims/sso-agent-for-jwt-webapp/pom.xml
@@ -110,6 +110,16 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary

- `sso-agent-for-jwt-webapp/pom.xml` has no `<parent>` declaration, so it does not inherit `pluginManagement` from `msf4j-parent`
- When `-P wso2-release` activates `maven-javadoc-plugin`, Maven resolves it to the latest available version (`3.12.0`) with `detectJavaApiLink=true` (the default), which fails under JDK 11 with: _"packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module"_
- All other modules inherit version `2.10.3` with `detectJavaApiLink=false` via `pluginManagement`; this standalone module was missed

**Fix:** Pin `maven-javadoc-plugin` to `2.10.3` and set `detectJavaApiLink=false` directly in the module's `<build><plugins>`, matching the configuration every other module gets through inheritance.

## Test plan

- [ ] Verify `mvn javadoc:jar -pl samples/jwt-claims/sso-agent-for-jwt-webapp` passes under JDK 11
- [ ] Re-run Jenkins release build and confirm `sso-agent-sample-webapp` no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)